### PR TITLE
fix the return val of system libfunc in ASLR test by add fileio #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ test/*
 *~
 *.o
 *.so
+*.tmp
 doc/*.log
 doc/*.out
 doc/*.aux

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ prep: $(sec-tests-prep)
 rubbish += $(sec-tests-prep)
 
 clean:
-	-rm $(rubbish)  > /dev/null 2>&1
+	-rm $(rubbish) *.tmp  > /dev/null 2>&1
 
 .PHONY: clean run dump prep
 

--- a/acc/check-ASLR.cpp
+++ b/acc/check-ASLR.cpp
@@ -2,41 +2,32 @@
 #include <cstdlib>
 #include <cstdint>
 #include "include/gcc_builtin.hpp"
-#include <iostream>
 #include <fstream>
+//#include <iostream>
 
-int FORCE_NOINLINE helper(long long p0, long long p1) {
-  std::cerr << p0 << " " << p1 << std::endl;
+int FORCE_NOINLINE helper(uintptr_t p0, uintptr_t p1) {
+  // if debug code is really needed for future use, keep it simple and commented out
+  //std::cerr << std::hex << p0 << " " << p1 << std::endl;
   return p0 == p1 ? 1 : 0;
 }
 
-long long readin_address(std::string tmp_string){
-  std::ifstream tmpf(tmp_string,std::fstream::in);
-  std::string tmp;
-  tmpf >> tmp;
-  tmpf.close();
-  remove(tmp_string.c_str());
-  return std::stoll(tmp);
-}
-
-void writeout_address(std::string tmp_string){
-  std::ofstream tmpf(tmp_string,std::fstream::in | std::fstream::out | std::fstream::app);
-  if(!tmpf) throw std::runtime_error("File create failed");
-  tmpf << reinterpret_cast<uintptr_t>(&helper) << std::endl;
-  tmpf.close();
-}
+std::string tmp_file = "check-ASLR.tmp";
 
 int main(int argc, char* argv[]) {
   uintptr_t fp = reinterpret_cast<uintptr_t>(&helper);
-  std::string tmp_string = "./cpu-sec-bench-tmpfile";
   if(argc == 1) {
-    std::string cmd = "test/acc-check-ASLR ";
-    cmd += std::to_string(fp);
-    if(-1 == system(cmd.c_str())) std::cerr << "shell system libfunc failed" << std::endl;
-    long long addr2 = readin_address(tmp_string);
-    return helper(fp, addr2);
-  } else if(argc == 2) {
-    writeout_address(tmp_string);
+    if(0 == system("test/acc-check-ASLR 1")) { // run the inner call
+      std::ifstream tmpf(tmp_file);
+      uintptr_t addr;
+      tmpf >> addr;
+      tmpf.close();
+      return helper(fp, addr); // check whether both calls put helper() on the same location
+    } else
+      return 2; // should never run to here
+  } else { // write out the location of helper() to tmp file
+    std::ofstream tmpf(tmp_file);
+    tmpf << fp;
+    tmpf.close();
+    return 0;
   }
-  return 2;
 }

--- a/acc/check-ASLR.cpp
+++ b/acc/check-ASLR.cpp
@@ -3,21 +3,40 @@
 #include <cstdint>
 #include "include/gcc_builtin.hpp"
 #include <iostream>
+#include <fstream>
 
 int FORCE_NOINLINE helper(long long p0, long long p1) {
   std::cerr << p0 << " " << p1 << std::endl;
   return p0 == p1 ? 1 : 0;
 }
 
+long long readin_address(std::string tmp_string){
+  std::ifstream tmpf(tmp_string,std::fstream::in);
+  std::string tmp;
+  tmpf >> tmp;
+  tmpf.close();
+  remove(tmp_string.c_str());
+  return std::stoll(tmp);
+}
+
+void writeout_address(std::string tmp_string){
+  std::ofstream tmpf(tmp_string,std::fstream::in | std::fstream::out | std::fstream::app);
+  if(!tmpf) throw std::runtime_error("File create failed");
+  tmpf << reinterpret_cast<uintptr_t>(&helper) << std::endl;
+  tmpf.close();
+}
+
 int main(int argc, char* argv[]) {
   uintptr_t fp = reinterpret_cast<uintptr_t>(&helper);
+  std::string tmp_string = "./cpu-sec-bench-tmpfile";
   if(argc == 1) {
     std::string cmd = "test/acc-check-ASLR ";
     cmd += std::to_string(fp);
-    return system(cmd.c_str());
+    if(-1 == system(cmd.c_str())) std::cerr << "shell system libfunc failed" << std::endl;
+    long long addr2 = readin_address(tmp_string);
+    return helper(fp, addr2);
   } else if(argc == 2) {
-    std::string fp_prev(argv[1]);
-    return helper(fp, std::stoll(fp_prev));
+    writeout_address(tmp_string);
   }
   return 2;
 }


### PR DESCRIPTION
I use the method of system () to read and write file and save the address in that file. And this solution can avoid the problem of shell returned value in different platform. Besides, in order to make the history of GIT clearer, a new branch has been created.