### PR TITLE
func: add class/array longer type-cast overflow test

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -1,4 +1,52 @@
 {
+    "mss-overflow-after-typecast-for-basictype-read-ptr-stack": {
+        "program": "mss-read-after-typecast-for-basictype",
+        "arguments": { "0": ["0"] }
+    },
+    "mss-overflow-after-typecast-for-basictype-read-ptr-heap": {
+        "program": "mss-read-after-typecast-for-basictype",
+        "arguments": { "0": ["1"] }
+    },
+    "mss-overflow-after-typecast-for-basictype-read-ptr-data": {
+        "program": "mss-read-after-typecast-for-basictype",
+        "arguments": { "0": ["2"] }
+    },
+    "mss-overflow-after-typecast-for-basictype-read-ptr-rodata": {
+        "program": "mss-read-after-typecast-for-basictype",
+        "arguments": { "0": ["3"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-read-ptr-stack": {
+        "program": "mss-read-after-typecast-for-expandedarray",
+        "arguments": { "0": ["0"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-read-ptr-heap": {
+        "program": "mss-read-after-typecast-for-expandedarray",
+        "arguments": { "0": ["1"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-read-ptr-data": {
+        "program": "mss-read-after-typecast-for-expandedarray",
+        "arguments": { "0": ["2"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-read-ptr-rodata": {
+        "program": "mss-read-after-typecast-for-expandedarray",
+        "arguments": { "0": ["3"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-read-ptr-stack": {
+        "program": "mss-read-after-typecast-for-expandedclass",
+        "arguments": { "0": ["0"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-read-ptr-heap": {
+        "program": "mss-read-after-typecast-for-expandedclass",
+        "arguments": { "0": ["1"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-read-ptr-data": {
+        "program": "mss-read-after-typecast-for-expandedclass",
+        "arguments": { "0": ["2"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-read-ptr-rodata": {
+        "program": "mss-read-after-typecast-for-expandedclass",
+        "arguments": { "0": ["3"] }
+    },
     "mss-overflow-read-index-stack": {
         "program": "mss-read-by-index",
         "arguments": { "0": ["0", "0"] },
@@ -64,6 +112,42 @@
     "mss-underflow-read-ptr-rodata": {
         "program": "mss-read-by-pointer",
         "arguments": { "0": ["3", "1"] }
+    },
+    "mss-overflow-after-typecast-for-basictype-write-ptr-stack": {
+        "program": "mss-write-after-typecast-for-basictype",
+        "arguments": { "0": ["0"] }
+    },
+    "mss-overflow-after-typecast-for-basictype-write-ptr-heap": {
+        "program": "mss-write-after-typecast-for-basictype",
+        "arguments": { "0": ["1"] }
+    },
+    "mss-overflow-after-typecast-for-basictype-write-ptr-data": {
+        "program": "mss-write-after-typecast-for-basictype",
+        "arguments": { "0": ["2"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-write-ptr-stack": {
+        "program": "mss-write-after-typecast-for-expandedarray",
+        "arguments": { "0": ["0"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-write-ptr-heap": {
+        "program": "mss-write-after-typecast-for-expandedarray",
+        "arguments": { "0": ["1"] }
+    },
+    "mss-overflow-after-typecast-for-expandedarray-write-ptr-data": {
+        "program": "mss-write-after-typecast-for-expandedarray",
+        "arguments": { "0": ["2"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-write-ptr-stack": {
+        "program": "mss-write-after-typecast-for-expandedclass",
+        "arguments": { "0": ["0"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-write-ptr-heap": {
+        "program": "mss-write-after-typecast-for-expandedclass",
+        "arguments": { "0": ["1"] }
+    },
+    "mss-overflow-after-typecast-for-expandedclass-write-ptr-data": {
+        "program": "mss-write-after-typecast-for-expandedclass",
+        "arguments": { "0": ["2"] }
     },
     "mss-overflow-write-index-stack": {
         "program": "mss-write-by-index",

--- a/lib/include/mss.hpp
+++ b/lib/include/mss.hpp
@@ -8,6 +8,24 @@ struct charBuffer
   char overflow[8];
 };
 
+class smallObject
+{
+  public:
+    char data[8] = "ddddddd";
+  private:
+    char overflow[8] = "fffffff";
+};
+class hugeObject
+{
+  public:
+    char data[64];
+};
+struct objectBuffer
+{
+  class smallObject data;
+  char overflow[8] = "ooooooo";
+};
+
 extern void char_buffer_init(charBuffer *, char uf, char d, char of);
 extern void update_by_index(charBuffer& cb, long long offset, long long size, int step, char c);
 extern void update_by_pointer(char *buf, long long offset, long long size, int step, char c);

--- a/mss/read-after-typecast-for-expandedarray.cpp
+++ b/mss/read-after-typecast-for-expandedarray.cpp
@@ -1,0 +1,40 @@
+#include "include/mss.hpp"
+
+const charBuffer buffer_rodata = {"uuuuuuu","ddddddd","ooooooo"};
+charBuffer buffer_data;
+
+int main(int argc, char* argv[])
+{
+  // buffer in data
+  char_buffer_init(&buffer_data, 'u', 'd', 'o');
+
+  // buffer in local stack
+  charBuffer buffer_stack;
+  char_buffer_init(&buffer_stack, 'u', 'd', 'o');
+
+  // buffer allocated in heap
+  charBuffer *buffer_heap = new charBuffer;
+  char_buffer_init(buffer_heap, 'u', 'd', 'o');
+
+  int store_type = argv[1][0] - '0';
+  switch(store_type){
+  case 0:{
+    char (&tmp0)[16] = reinterpret_cast<char (&)[16]>(buffer_stack.data);
+    /*To type-cast array[8] to array[16], then read the latter 8 elements.
+    If these elements can be read by tmpX pointer, it means that the integrity of the information has been compromised. */
+    return check(tmp0+8,7,1,'o');
+  }
+  case 1:{
+    char (&tmp1)[16] = reinterpret_cast<char (&)[16]>(buffer_heap->data);
+    return check(tmp1+8,7,1,'o');
+  }
+  case 2:{
+    char (&tmp2)[16] = reinterpret_cast<char (&)[16]>(buffer_data.data);
+    return check(tmp2+8,7,1,'o');
+  }
+  case 3:{
+    const char (&tmp3)[16] = reinterpret_cast<char (&)[16]>(buffer_data.data);
+    return check(tmp3+8,7,1,'o');
+  }
+  }
+}

--- a/mss/read-after-typecast-for-expandedclass.cpp
+++ b/mss/read-after-typecast-for-expandedclass.cpp
@@ -1,0 +1,34 @@
+#include "include/mss.hpp"
+
+const objectBuffer buffer_rodata;
+// buffer in data
+objectBuffer buffer_data;
+
+int main(int argc, char* argv[])
+{
+  // buffer in local stack
+  objectBuffer buffer_stack;
+
+  // buffer allocated in heap
+  objectBuffer *buffer_heap = new objectBuffer;
+
+  int store_type = argv[1][0] - '0';
+  switch(store_type){
+  case 0:{
+    class hugeObject* tmp0 = reinterpret_cast<class hugeObject* >(&buffer_stack.data);
+    return check(tmp0->data+16,7,1,'o');
+  }
+  case 1:{
+    class hugeObject* tmp1 = reinterpret_cast<class hugeObject* >(&buffer_heap->data);
+    return check(tmp1->data+16,7,1,'o');
+  }
+  case 2:{
+    class hugeObject* tmp2 = reinterpret_cast<class hugeObject* >(&buffer_data.data);
+    return check(tmp2->data+16,7,1,'o');
+  }
+  case 3:{
+    const class hugeObject* tmp3 = reinterpret_cast<const class hugeObject* >(&buffer_rodata.data);
+    return check(tmp3->data+16,7,1,'o');
+  }
+  }
+}

--- a/mss/write-after-typecast-for-expandedarray.cpp
+++ b/mss/write-after-typecast-for-expandedarray.cpp
@@ -1,0 +1,39 @@
+#include "include/mss.hpp"
+
+const charBuffer buffer_rodata = {"uuuuuuu","ddddddd","ooooooo"};
+charBuffer buffer_data;
+
+int main(int argc, char* argv[])
+{
+  // buffer in data
+  char_buffer_init(&buffer_data, 'u', 'd', 'o');
+
+  // buffer in local stack
+  charBuffer buffer_stack;
+  char_buffer_init(&buffer_stack, 'u', 'd', 'o');
+
+  // buffer allocated in heap
+  charBuffer *buffer_heap = new charBuffer;
+  char_buffer_init(buffer_heap, 'u', 'd', 'o');
+
+  int store_type = argv[1][0] - '0';
+  switch(store_type){
+  case 0:{
+    char (&tmp0)[16] = *static_cast<char (*)[16]>(static_cast<void*>(&buffer_stack.data));
+    /*To type-cast array[8] to array[16], then update the latter 8 elements.
+    If these elements readed by normal way(overflow array) are equal to the target char, it means that the information has been written. */
+    update_by_pointer(tmp0,  8,  8,  1, 'c');
+    return check(buffer_stack.overflow,  8,  1, 'c');
+  }
+  case 1:{
+    char (&tmp1)[16] = *static_cast<char (*)[16]>(static_cast<void*>(&buffer_heap->data));
+    update_by_pointer(tmp1,  8,  8,  1, 'c');
+    return check(buffer_heap->overflow,  8,  1, 'c');
+  }
+  case 2:{
+    char (&tmp2)[16] = *static_cast<char (*)[16]>(static_cast<void*>(&buffer_data.data));
+    update_by_pointer(tmp2,  8,  8,  1, 'c');
+    return check(buffer_data.overflow,  8,  1, 'c'); 
+  }
+  }
+}

--- a/mss/write-after-typecast-for-expandedclass.cpp
+++ b/mss/write-after-typecast-for-expandedclass.cpp
@@ -1,0 +1,32 @@
+#include "include/mss.hpp"
+
+// buffer in data
+objectBuffer buffer_data;
+
+int main(int argc, char* argv[])
+{
+  // buffer in local stack
+  objectBuffer buffer_stack;
+
+  // buffer allocated in heap
+  objectBuffer *buffer_heap = new objectBuffer;
+
+  int store_type = argv[1][0] - '0';
+  switch(store_type){
+  case 0:{
+    class hugeObject* tmp0 = reinterpret_cast<class hugeObject* >(&buffer_stack.data);
+    update_by_pointer(tmp0->data,16,7,1,'c');
+    return check(tmp0->data+16,7,1,'c');
+  }
+  case 1:{
+    class hugeObject* tmp1 = reinterpret_cast<class hugeObject* >(&buffer_heap->data);
+    update_by_pointer(tmp1->data,16,7,1,'c');
+    return check(tmp1->data+16,7,1,'c');
+  }
+  case 2:{
+    class hugeObject* tmp2 = reinterpret_cast<class hugeObject* >(&buffer_data.data);
+    update_by_pointer(tmp2->data,16,7,1,'c');
+    return check(tmp2->data+16,7,1,'c');
+  }
+  }
+}


### PR DESCRIPTION
1. add write test for basic type-cast overflow(struct's member)
2. add typecast short array/class to longer array/class, test both read and write capbability.