### PR TITLE
feat: add redzone check between class (#12)

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -1,23 +1,43 @@
 {
-    "mss-check-stack-redzone":{
+    "mss-check-class-stack-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["0"]},
         "set-var": { "0": "redzone_class_var_stack"}
     },
-    "mss-check-heap-redzone":{
+    "mss-check-class-heap-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["1"]},
         "set-var": { "0": "redzone_class_var_heap"}
     },
-    "mss-check-data-redzone":{
+    "mss-check-class-data-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["2"]},
         "set-var": { "0": "redzone_class_var_data"}
     },
-    "mss-check-rodata-redzone":{
+    "mss-check-class-rodata-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["3"]},
         "set-var": { "0": "redzone_class_var_rodata"}
+    },
+    "mss-check-insideclass-stack-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["4"]},
+        "set-var": { "0": "redzone_inside_class_var_stack"}
+    },
+    "mss-check-insideclass-heap-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["5"]},
+        "set-var": { "0": "redzone_inside_class_var_heap"}
+    },
+    "mss-check-insideclass-data-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["6"]},
+        "set-var": { "0": "redzone_inside_class_var_data"}
+    },
+    "mss-check-insideclass-rodata-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["7"]},
+        "set-var": { "0": "redzone_inside_class_var_rodata"}
     },
     "mss-overflow-read-index-stack": {
         "program": "mss-read-by-index",

--- a/mss/check-redzone.cpp
+++ b/mss/check-redzone.cpp
@@ -2,8 +2,11 @@
 #include "include/assembly.hpp"
 
 const charBuffer buffer_rodata('u','d','o');
+const charBuffer buffer_rodata_dup('u','d','o');
+
 // buffer in data
 charBuffer buffer_data('u','d','o');
+charBuffer buffer_data_dup('u','d','o');
 
 /*We use the range [32,64) in return val to save global var,
  *But redzone's maxinum length can over 128 byte.
@@ -21,22 +24,31 @@ int main(int argc, char* argv[])
 
   // buffer in local stack
   charBuffer buffer_stack('u','d','o');
+  charBuffer buffer_stack_dup('u','d','o');
 
   // buffer allocated in heap
   charBuffer *buffer_heap = new charBuffer('u','d','o');
+  charBuffer *buffer_heap_dup = new charBuffer('u','d','o');
 
   int store_type = argv[1][0] - '0';
 
-  long long length;
+  long long length = 0;
 
   switch(store_type) {
-  case 0: GET_DISTANCE(length, buffer_stack.data, buffer_stack.underflow); break;
-  case 1: GET_DISTANCE(length, buffer_heap->data, buffer_heap->underflow); break;
-  case 2: GET_DISTANCE(length, buffer_data.data, buffer_data.underflow); break;
-  case 3: GET_DISTANCE(length, buffer_rodata.data, buffer_rodata.underflow); break;
+  //get the redzone len of objects inside class
+    case 0: GET_DISTANCE(length, &buffer_stack_dup, &buffer_stack);break;
+    case 1: GET_DISTANCE(length, buffer_heap_dup, buffer_heap); break;
+    case 2: GET_DISTANCE(length, &buffer_data, &buffer_data_dup); break;
+    case 3: GET_DISTANCE(length, &buffer_rodata, &buffer_rodata_dup); break;
+  //get the redzone len of objects between class
+    case 4: GET_DISTANCE(length, buffer_stack.data, buffer_stack.underflow); break;
+    case 5: GET_DISTANCE(length, buffer_heap->data, buffer_heap->underflow); break;
+    case 6: GET_DISTANCE(length, buffer_data.data, buffer_data.underflow); break;
+    case 7: GET_DISTANCE(length, buffer_rodata.data, buffer_rodata.underflow); break;
   }
 
   delete buffer_heap; // delete it to avoid trigger memory leak detection by ASan
+  delete buffer_heap_dup;
 
   /* Because each mem areas may have redzones with different lens 
   *  So it's necessary to use multiple testcases to check whether this kind mem has a redzone.


### PR DESCRIPTION
The growth direction of the global variable area is inconsistent with that of the stack area. And the reconstruction of return runtime-variable method is needed, as gcc's redzone grow 8 bytes at once instead of multiplying by 2.