### PR TITLE
feat: add redzone check between class

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -1,23 +1,43 @@
 {
-    "mss-check-stack-redzone":{
+    "mss-check-inter-stack-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["0"]},
-        "set-var": { "0": "redzone_class_var_stack"}
+        "set-var": { "0": "redzone_inter_var_stack"}
     },
-    "mss-check-heap-redzone":{
+    "mss-check-inter-heap-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["1"]},
-        "set-var": { "0": "redzone_class_var_heap"}
+        "set-var": { "0": "redzone_inter_var_heap"}
     },
-    "mss-check-data-redzone":{
+    "mss-check-inter-data-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["2"]},
-        "set-var": { "0": "redzone_class_var_data"}
+        "set-var": { "0": "redzone_inter_var_data"}
     },
-    "mss-check-rodata-redzone":{
+    "mss-check-inter-rodata-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["3"]},
-        "set-var": { "0": "redzone_class_var_rodata"}
+        "set-var": { "0": "redzone_inter_var_rodata"}
+    },
+    "mss-check-intro-stack-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["4"]},
+        "set-var": { "0": "redzone_intro_var_stack"}
+    },
+    "mss-check-intro-heap-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["5"]},
+        "set-var": { "0": "redzone_intro_var_heap"}
+    },
+    "mss-check-intro-data-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["6"]},
+        "set-var": { "0": "redzone_intro_var_data"}
+    },
+    "mss-check-intro-rodata-redzone":{
+        "program": "mss-check-redzone",
+        "arguments": { "0": ["7"]},
+        "set-var": { "0": "redzone_intro_var_rodata"}
     },
     "mss-overflow-read-index-stack": {
         "program": "mss-read-by-index",

--- a/configure.json
+++ b/configure.json
@@ -1,43 +1,43 @@
 {
-    "mss-check-inter-stack-redzone":{
+    "mss-check-inter-obj-stack-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["0"]},
-        "set-var": { "0": "redzone_inter_var_stack"}
+        "set-var": { "0": "redzone_inter_obj_stack"}
     },
-    "mss-check-inter-heap-redzone":{
+    "mss-check-inter-obj-heap-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["1"]},
-        "set-var": { "0": "redzone_inter_var_heap"}
+        "set-var": { "0": "redzone_inter_obj_heap"}
     },
-    "mss-check-inter-data-redzone":{
+    "mss-check-inter-obj-data-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["2"]},
-        "set-var": { "0": "redzone_inter_var_data"}
+        "set-var": { "0": "redzone_inter_obj_data"}
     },
-    "mss-check-inter-rodata-redzone":{
+    "mss-check-inter-obj-rodata-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["3"]},
-        "set-var": { "0": "redzone_inter_var_rodata"}
+        "set-var": { "0": "redzone_inter_obj_rodata"}
     },
-    "mss-check-intro-stack-redzone":{
+    "mss-check-intra-obj-stack-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["4"]},
-        "set-var": { "0": "redzone_intro_var_stack"}
+        "set-var": { "0": "redzone_intra_obj_stack"}
     },
-    "mss-check-intro-heap-redzone":{
+    "mss-check-intra-obj-heap-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["5"]},
-        "set-var": { "0": "redzone_intro_var_heap"}
+        "set-var": { "0": "redzone_intra_obj_heap"}
     },
-    "mss-check-intro-data-redzone":{
+    "mss-check-intra-obj-data-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["6"]},
-        "set-var": { "0": "redzone_intro_var_data"}
+        "set-var": { "0": "redzone_intra_obj_data"}
     },
-    "mss-check-intro-rodata-redzone":{
+    "mss-check-intra-obj-rodata-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["7"]},
-        "set-var": { "0": "redzone_intro_var_rodata"}
+        "set-var": { "0": "redzone_intra_obj_rodata"}
     },
     "mss-overflow-read-index-stack": {
         "program": "mss-read-by-index",

--- a/mss/check-redzone.cpp
+++ b/mss/check-redzone.cpp
@@ -1,5 +1,6 @@
 #include "include/mss.hpp"
 #include "include/assembly.hpp"
+#include <cstdlib>
 
 const charBuffer buffer_rodata('u','d','o');
 const charBuffer buffer_rodata_dup('u','d','o');
@@ -15,7 +16,6 @@ charBuffer buffer_data_dup('u','d','o');
 */
 inline int getPower(long long num){
   int ret = 0;
-  if(num < 0) num = -num;
   while(num >>= 1) ret++;
   return ret;
 }
@@ -36,12 +36,10 @@ int main(int argc, char* argv[])
   long long length = 0;
 
   switch(store_type) {
-  //get the redzone len between objects 
     case 0: GET_DISTANCE(length, &buffer_stack, &buffer_stack_dup);break;
     case 1: GET_DISTANCE(length, buffer_heap, buffer_heap_dup); break;
     case 2: GET_DISTANCE(length, &buffer_data, &buffer_data_dup); break;
     case 3: GET_DISTANCE(length, &buffer_rodata, &buffer_rodata_dup); break;
-  //get the redzone len inside objects
     case 4: GET_DISTANCE(length, buffer_stack.data, buffer_stack.underflow); break;
     case 5: GET_DISTANCE(length, buffer_heap->data, buffer_heap->underflow); break;
     case 6: GET_DISTANCE(length, buffer_data.data, buffer_data.underflow); break;
@@ -56,10 +54,7 @@ int main(int argc, char* argv[])
   *  And we use getdistance to determine whether it exists, 
   *  then natuarlly to combine "check" and "getXXXlen" into one test.
   */
-  if(store_type < 4 && length != 0)
-    length < 0 ? length += sizeof(charBuffer) : length -= sizeof(charBuffer);
-  else if(store_type >= 4 && length != 0)
-    length < 0 ? length += CB_BUF_LEN         : length -= CB_BUF_LEN;
-
+  length = abs(length);
+  length -= store_type < 4 ? sizeof(charBuffer) : CB_BUF_LEN;
   return 32 + getPower(length);
 }

--- a/mss/check-redzone.cpp
+++ b/mss/check-redzone.cpp
@@ -2,8 +2,11 @@
 #include "include/assembly.hpp"
 
 const charBuffer buffer_rodata('u','d','o');
+const charBuffer buffer_rodata_dup('u','d','o');
+
 // buffer in data
 charBuffer buffer_data('u','d','o');
+charBuffer buffer_data_dup('u','d','o');
 
 /*We use the range [32,64) in return val to save global var,
  *But redzone's maxinum length can over 128 byte.
@@ -12,6 +15,7 @@ charBuffer buffer_data('u','d','o');
 */
 inline int getPower(long long num){
   int ret = 0;
+  if(num < 0) num = -num;
   while(num >>= 1) ret++;
   return ret;
 }
@@ -21,28 +25,41 @@ int main(int argc, char* argv[])
 
   // buffer in local stack
   charBuffer buffer_stack('u','d','o');
+  charBuffer buffer_stack_dup('u','d','o');
 
   // buffer allocated in heap
   charBuffer *buffer_heap = new charBuffer('u','d','o');
+  charBuffer *buffer_heap_dup = new charBuffer('u','d','o');
 
   int store_type = argv[1][0] - '0';
 
-  long long length;
+  long long length = 0;
 
   switch(store_type) {
-  case 0: GET_DISTANCE(length, buffer_stack.data, buffer_stack.underflow); break;
-  case 1: GET_DISTANCE(length, buffer_heap->data, buffer_heap->underflow); break;
-  case 2: GET_DISTANCE(length, buffer_data.data, buffer_data.underflow); break;
-  case 3: GET_DISTANCE(length, buffer_rodata.data, buffer_rodata.underflow); break;
+  //get the redzone len between objects 
+    case 0: GET_DISTANCE(length, &buffer_stack, &buffer_stack_dup);break;
+    case 1: GET_DISTANCE(length, buffer_heap, buffer_heap_dup); break;
+    case 2: GET_DISTANCE(length, &buffer_data, &buffer_data_dup); break;
+    case 3: GET_DISTANCE(length, &buffer_rodata, &buffer_rodata_dup); break;
+  //get the redzone len inside objects
+    case 4: GET_DISTANCE(length, buffer_stack.data, buffer_stack.underflow); break;
+    case 5: GET_DISTANCE(length, buffer_heap->data, buffer_heap->underflow); break;
+    case 6: GET_DISTANCE(length, buffer_data.data, buffer_data.underflow); break;
+    case 7: GET_DISTANCE(length, buffer_rodata.data, buffer_rodata.underflow); break;
   }
 
   delete buffer_heap; // delete it to avoid trigger memory leak detection by ASan
+  delete buffer_heap_dup;
 
   /* Because each mem areas may have redzones with different lens 
   *  So it's necessary to use multiple testcases to check whether this kind mem has a redzone.
   *  And we use getdistance to determine whether it exists, 
   *  then natuarlly to combine "check" and "getXXXlen" into one test.
   */
-  length -= CB_BUF_LEN;
+  if(store_type < 4 && length != 0)
+    length < 0 ? length += sizeof(charBuffer) : length -= sizeof(charBuffer);
+  else if(store_type >= 4 && length != 0)
+    length < 0 ? length += CB_BUF_LEN         : length -= CB_BUF_LEN;
+
   return 32 + getPower(length);
 }


### PR DESCRIPTION
 * The growth direction of the global variable area is inconsistent with that of the stack area.
 * The reconstruction of return runtime-variable method is needed, as gcc's redzone grow 8 bytes at once instead of multiplying by 2.
 * Add a conditional judgment on length.
 * Take the directionality of redzone into consideration.