### PR TITLE
fix:  undefined reference when make run-test(had enable extra securit…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ all: run-test
 run-test: $(base)/scheduler/run-test.cpp $(base)/lib/common/temp_file.cpp $(base)/lib/include/temp_file.hpp $(base)/scheduler/json.hpp $(test-path)/sys_info.txt
 	$(CXX) -O2 --std=c++11 -I. -I./lib  $< $(base)/lib/common/temp_file.cpp -o $@
 
-rubbish += run-test $(base)/lib/common/temp_file.o
+rubbish += run-test
 
 $(test-path)/sys_info.txt:
 	-mkdir -p $(test-path)

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ endif
 ifdef enable_address_sanitizer
   CXXFLAGS += -fsanitize=address --param=asan-stack=1
 ifeq ($(CXX),clang++)
-	LDFLAGS  += -static-libsan 
+  LDFLAGS  += -static-libsan
 else
   LDFLAGS  += -static-libasan
 endif
@@ -126,10 +126,10 @@ all: run-test
 .PHONY: all
 
 # json.hpp needs C++11, which might be problematic on some systems
-run-test: $(base)/scheduler/run-test.cpp $(base)/lib/common/temp_file.o $(base)/scheduler/json.hpp $(test-path)/sys_info.txt
-	$(CXX) -O2 --std=c++11 -I. $< $(base)/lib/common/temp_file.o -o $@
+run-test: $(base)/scheduler/run-test.cpp $(base)/lib/common/temp_file.cpp $(base)/lib/include/temp_file.hpp $(base)/scheduler/json.hpp $(test-path)/sys_info.txt
+	$(CXX) -O2 --std=c++11 -I. -I./lib  $< $(base)/lib/common/temp_file.cpp -o $@
 
-rubbish += run-test
+rubbish += run-test $(base)/lib/common/temp_file.o
 
 $(test-path)/sys_info.txt:
 	-mkdir -p $(test-path)


### PR DESCRIPTION
…y features)

  Due to different CXXFLAG between run-test and test units,
  there are sec-feat-lib variable declarations in temp_file.o.
  And When ld is linking target files, the makefile rule under run-test:
  hasn'	t specify the corresponding options.
  Use overriding the generate rule of temp-file.o under run-test:
  to solve this bug.