### PR TITLE
fix: add inter-alloc redzone check-len test

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -9,6 +9,9 @@
         "arguments": { "0": ["1"]},
         "set-var": { "0": "redzone_inter_obj_heap"}
     },
+    "mss-check-inter-obj-heap-redzone":{
+        "program": "mss-check-inter-alloc-redzone"
+    },
     "mss-check-inter-obj-data-redzone":{
         "program": "mss-check-redzone",
         "arguments": { "0": ["2"]},

--- a/mss/check-inter-alloc-redzone.cpp
+++ b/mss/check-inter-alloc-redzone.cpp
@@ -1,0 +1,28 @@
+#include "include/mss.hpp"
+#include "include/assembly.hpp"
+#include <vector>
+#include <cstdlib>
+#include <malloc.h>
+
+int main(){
+
+  /* Asan has hijacked "new","delete","malloc","free","malloc_usable_size"
+     and other mem accessfunctions, 
+     so I create an array whose length is not aligned on purpose. 
+     If ASAN is not enabled, normal malloc will align it, used_ len！= unaligned_ len
+     If ASAN is enabled, modified malloc will use unwritealbe region align it,
+     which can be observed by malloc_usable_size().
+     And used_len will equal unaligned_len.
+  */
+  for(int i = 1; i != 8; i++){
+    size_t unaligned_len = (0x1LL << i) - 1;
+    char* test_heap = new char[unaligned_len];
+    size_t used_len = malloc_usable_size(test_heap);
+    if(used_len != unaligned_len){
+      delete[] test_heap;
+      return 0;
+    }
+      delete[] test_heap;
+  }
+  return -1;
+}


### PR DESCRIPTION
  /* enable redzone*/
  // used_len is: 1 unaligned_len is: 1
  // used_len is: 3 unaligned_len is: 3
  // used_len is: 7 unaligned_len is: 7
  // used_len is: 15 unaligned_len is: 15
  // used_len is: 31 unaligned_len is: 31
  // used_len is: 63 unaligned_len is: 63
  // used_len is: 127 unaligned_len is: 127

  /* unenable redzone*/
  // used_len is: 24 unaligned_len is: 1
  // used_len is: 24 unaligned_len is: 3
  // used_len is: 24 unaligned_len is: 7
  // used_len is: 24 unaligned_len is: 15
  // used_len is: 40 unaligned_len is: 31
  // used_len is: 72 unaligned_len is: 63
  // used_len is: 136 unaligned_len is: 127