### PR TITLE
fix: fix read-func by read nth inst statically and check it dynamicly

### DIFF
--- a/acc/read-func.cpp
+++ b/acc/read-func.cpp
@@ -1,5 +1,14 @@
 #include "include/assembly.hpp"
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <cstdlib>
 
+#include <iostream>
+
+unsigned int code_num    = 0;
+unsigned int code_mask   = 0;
+unsigned int inst_byte_offset = 0;
 /*
  * If a local variable is modified by an embedded assembly,
  * it might be removed by Clang 12 on Mac M1.
@@ -20,24 +29,61 @@
  * Relax the check by reading both locations.
  */
 
-int FORCE_NOINLINE helper(int var, int cet, int sum) {
-  unsigned int *code = (unsigned int *)(&&CHECK_POS);
-  unsigned int *code_cet = code + cet;
-  COMPILER_BARRIER;
- CHECK_POS:
-  var += cet;
-  COMPILER_BARRIER;
-  return (var == sum &&
-          (
-           ((*code    ) & READ_FUNC_MASK) == READ_FUNC_CODE ||
-           ((*code_cet) & READ_FUNC_MASK) == READ_FUNC_CODE
-          )
-         )
-    ? 0 : 1;
+int FORCE_NOINLINE helper(int var) {
+  unsigned char *code = (unsigned char *)(&helper);
+  code += inst_byte_offset;
+  return ((*(unsigned int*)code) & code_mask) == code_num 
+         ? 0 : 1;
 }
 
 int main(int argc, char* argv[]) {
   int var = argv[1][0] - '0';
-  int cet = argv[2][0] - '0';
-  return helper(var, cet, var+cet);
+
+  std::string fname = "./helper_fun.tmp";
+  std::string cmd = "objdump -C --disassemble=\"helper(int)\" \
+                    -j.text test/acc-read-func --show-raw-insn";
+  std::string target = cmd + ">" + fname;
+
+  int inst_th = 5;
+  if(system(target.c_str()) == 0){
+    std::ifstream tmpf(fname);
+    if(tmpf.good()){
+      std::string line;
+      bool is_inst_data = false;
+
+      while(std::getline(tmpf,line)){
+        if(line.find("<helper(int)>") != std::string::npos){
+          is_inst_data = true;
+        }
+        if(is_inst_data && inst_th != 0){
+          inst_th--;
+          std::istringstream firstopcode(line);
+          std::getline(firstopcode,line,'\t');
+          std::getline(firstopcode,line,'\t');
+          firstopcode.str(line);
+          
+          if(inst_th != 0){
+            int drop_num;
+            while(firstopcode >> std::hex >> drop_num){
+              inst_byte_offset++;
+            }
+          }else{
+            int bytes_num = 0, tmp_num;
+            while(firstopcode >> std::hex >> tmp_num){
+              tmp_num <<= bytes_num;
+              code_num |= tmp_num;code_mask |= (0xff << bytes_num);
+              bytes_num += 8;
+            }
+          }
+        }
+      }
+      std::cerr << "code_num is: " << std::hex << code_num << std::endl;
+      std::cerr << "code_mask is: " << std::hex << code_mask << std::endl;
+      std::cerr << "inst_byte_offset is: " << std::dec << inst_byte_offset << std::endl;
+    }
+  }
+  else{
+    return 2;
+  }
+  return helper(var);
 }

--- a/lib/aarch64/assembly.hpp
+++ b/lib/aarch64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0b000020
-#define READ_FUNC_MASK 0xffffffe0
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/common/temp_file.cpp
+++ b/lib/common/temp_file.cpp
@@ -3,7 +3,7 @@
 
 std::string temp_file_name(const std::string& cmd, const std::list<std::string>& glist) {
   std::string fn = cmd;
-  for(auto const g:glist) fn += "_" + g;
+  for(auto const &g:glist) fn += "_" + g;
   fn += ".tmp";
   return fn;
 }

--- a/lib/riscv64/assembly.hpp
+++ b/lib/riscv64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x00009d2d
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/x86_64/assembly.hpp
+++ b/lib/x86_64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // x86_64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0000f701
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \


### PR DESCRIPTION
Considering that the purpose of the test is to read the instructions in the function, I use objdump directly to read the number of instructions and record the offset of instructions(especially for x86 var-len inst, but also works for fixed-len inst as arm or riscv), and then add offset in the function start address. This method has bypassed CET with the compailer flag CHECK_POS. 

Besides, it also solves a potential problem in the original method that if there is a CET, the code address will be added by one(unsigned int*), that is, four bytes. However, the previous instruction of the current instruction may not necessarily be endbr (four bytes), may be 3 bytes or 5 bytes or more.
 