### PR TITLE
fix: read-func by using static func info and spliting architecture re…

### DIFF
--- a/acc/get-static-funcinfo.cpp
+++ b/acc/get-static-funcinfo.cpp
@@ -1,0 +1,27 @@
+#include "include/assembly.hpp"
+#include "include/temp_file.hpp"
+#include <fstream>
+#include <sstream>
+  
+int main(int argc, char* argv[]){
+
+  int inst_th = 5;
+
+  std::string proc_name = "./test/acc-read-func";
+  std::string func_name = "helper";
+  std::string file_name = "./test/helper_fun.tmp";
+
+  unsigned int code_num;
+  unsigned int code_mask;
+  unsigned int inst_byte_offset;
+
+  if(run_dump_cmd(proc_name,func_name,file_name) == 0){
+    if(get_nth_func_inst(code_num,code_mask,inst_byte_offset,file_name,inst_th) == 0){
+
+      write_to_temp_file(code_num, argc, argv);
+      write_to_temp_file(code_mask, argc, argv);
+      write_to_temp_file(inst_byte_offset, argc, argv);
+    }else return 2;
+  }else return 2;
+  return 64;
+}

--- a/acc/read-func.cpp
+++ b/acc/read-func.cpp
@@ -1,5 +1,9 @@
 #include "include/assembly.hpp"
+#include <cstdlib>
 
+unsigned int code_num    = 0;
+unsigned int code_mask   = 0;
+unsigned int inst_byte_offset = 0;
 /*
  * If a local variable is modified by an embedded assembly,
  * it might be removed by Clang 12 on Mac M1.
@@ -20,24 +24,18 @@
  * Relax the check by reading both locations.
  */
 
-int FORCE_NOINLINE helper(int var, int cet, int sum) {
-  unsigned int *code = (unsigned int *)(&&CHECK_POS);
-  unsigned int *code_cet = code + cet;
-  COMPILER_BARRIER;
- CHECK_POS:
-  var += cet;
-  COMPILER_BARRIER;
-  return (var == sum &&
-          (
-           ((*code    ) & READ_FUNC_MASK) == READ_FUNC_CODE ||
-           ((*code_cet) & READ_FUNC_MASK) == READ_FUNC_CODE
-          )
-         )
-    ? 0 : 1;
+int FORCE_NOINLINE helper(int var) {
+  unsigned char *code = (unsigned char *)(&helper);
+  code += inst_byte_offset;
+  return ((*(unsigned int*)code) & code_mask) == code_num
+         ? 0 : 1;
 }
 
 int main(int argc, char* argv[]) {
   int var = argv[1][0] - '0';
-  int cet = argv[2][0] - '0';
-  return helper(var, cet, var+cet);
+  code_num         = (unsigned int)atoi(argv[2]);
+  code_mask        = (unsigned int)atoi(argv[3]);
+  inst_byte_offset = (unsigned int)atoi(argv[4]);
+
+  return helper(var);
 }

--- a/configure.json
+++ b/configure.json
@@ -595,9 +595,14 @@
     "acc-check-ASLR": {
         "expect-results": { "1": "ASLR enabled."}
     },
+    "acc-get-static-funcinfo":{
+        "set-var": { "0": "inst-opcode",
+                     "1": "inst-mask",
+                     "2": "inst-byte-offset"}
+    },
     "acc-read-func": {
-        "require": { "0": [ [ "acc-check-CET" ] ] },
-        "arguments": {"0": ["1", "-vcet-enabled"] }
+        "require": { "0": [[ "acc-get-static-funcinfo" ]]},
+        "arguments": {"0": ["1","-vinst-opcode","-vinst-mask","-vinst-byte-offset"]}
     },
     "acc-get-ra-offset-v-p-g0": {
         "program": "acc-get-ra-offset",

--- a/lib/aarch64/assembly.cpp
+++ b/lib/aarch64/assembly.cpp
@@ -1,5 +1,7 @@
 #include "include/assembly.hpp"
 #include <stdlib.h>
+#include <sstream>
+#include <fstream>
 
 //#define DEBUG_READ_GOT
 
@@ -134,3 +136,37 @@ void replace_got_func(void **fake, void *got) {
 
 }
 
+int run_dump_cmd(const std::string& procname,
+                 const std::string& funcname, const std::string& filename){
+  std::string cmd = "./script/get_aarch64_func_inst.sh " + procname + " "
+                    + funcname + " " + filename;
+  return system(cmd.c_str());
+}
+
+int get_nth_func_inst(unsigned int& num,unsigned int& mask,
+                       unsigned int& offset,const std::string name, int nth){
+  num = mask = offset = 0;
+  std::ifstream tmpf(name);
+  if(tmpf.good()){
+    std::string line;
+    while(nth--){
+      std::getline(tmpf,line);
+      std::istringstream firstopcode(line);
+
+      if(nth != 0){
+        int drop_num;
+        while(firstopcode >> std::hex >> drop_num){
+          offset++;
+        }
+      }else{
+        int bytes_num = 0, tmp_num;
+        while(firstopcode >> std::hex >> tmp_num){
+          tmp_num <<= bytes_num;
+          num |= tmp_num;mask |= (0xff << bytes_num);
+          bytes_num += 8;
+        }
+      }
+    }
+    return 0;
+  }else return 2;
+}

--- a/lib/aarch64/assembly.hpp
+++ b/lib/aarch64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0b000020
-#define READ_FUNC_MASK 0xffffffe0
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/common/temp_file.cpp
+++ b/lib/common/temp_file.cpp
@@ -3,7 +3,7 @@
 
 std::string temp_file_name(const std::string& cmd, const std::list<std::string>& glist) {
   std::string fn = cmd;
-  for(auto const g:glist) fn += "_" + g;
+  for(auto const &g:glist) fn += "_" + g;
   fn += ".tmp";
   return fn;
 }
@@ -16,8 +16,8 @@ void write_to_temp_file(int var, int argc, char **argv) {
   }
   fn += ".tmp";
 
-  std::ofstream f(fn);
-  f << var;
+  std::ofstream f(fn,std::ofstream::app);
+  f << var << "\n";
   f.close();
 }
 

--- a/lib/include/assembly.hpp
+++ b/lib/include/assembly.hpp
@@ -3,6 +3,7 @@
 #ifndef ASSEMBLY_HPP_INCLUDED
 #define ASSEMBLY_HPP_INCLUDED
 
+#include <string>
 #include "include/gcc_builtin.hpp"
 
 // a barrier to stop compiler from reorder memory operations
@@ -41,5 +42,10 @@
 
 extern void get_got_func(void **gotp, void *label, int cet);
 extern void replace_got_func(void **fake, void *got);
+
+int run_dump_cmd(const std::string& procname,
+                 const std::string& funcname, const std::string& filename);
+int get_nth_func_inst(unsigned int& num,unsigned int& mask, 
+                       unsigned int& offset,const std::string name, int nth);
 
 #endif // ASSEMBLY_HPP_INCLUDED

--- a/lib/riscv64/assembly.hpp
+++ b/lib/riscv64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x00009d2d
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/x86_64/assembly.hpp
+++ b/lib/x86_64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // x86_64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0000f701
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/scheduler/run-test.cpp
+++ b/scheduler/run-test.cpp
@@ -146,7 +146,7 @@ std::list<std::string> collect_case_list() {
   return rv;
 }
 
-int case_parser(const std::string& cn, std::string& pn, str_llist_t& arg_list, std::string& vn,
+int case_parser(const std::string& cn, std::string& pn, str_llist_t& arg_list, str_list_t& vn,
                  std::set<int> &expect_results, std::set<int> &retry_results) {
   // check whether the case exist
   if(!config_db.count(cn)) {
@@ -157,9 +157,9 @@ int case_parser(const std::string& cn, std::string& pn, str_llist_t& arg_list, s
   auto tcase = config_db[cn];
 
   // check requirement
-  int req_case = 0;
-  std::string req_case_str = "0";
   if(tcase.count("require")) {
+    std::string req_case_str = "0";
+    int  req_case = 0;
     bool req_case_all_tested = true;
     bool req_case_tested = false;
     bool req_case_ok = false;
@@ -213,7 +213,7 @@ int case_parser(const std::string& cn, std::string& pn, str_llist_t& arg_list, s
   arg_list.clear();
   arg_list.push_back(str_list_t());
   if(tcase.count("arguments")) {
-    auto arguments = tcase["arguments"][req_case_str].get<str_list_t>();
+    auto arguments = tcase["arguments"]["0"].get<str_list_t>();
     for(auto arg : arguments) {
       if(arg.size() >= 3) {
         auto atype = arg.substr(0,2);
@@ -264,8 +264,13 @@ int case_parser(const std::string& cn, std::string& pn, str_llist_t& arg_list, s
   }
 
   // check whether the case store a global variable
-  if(tcase.count("set-var") && tcase["set-var"].count(req_case_str)) {
-    vn = tcase["set-var"][req_case_str].get<std::string>();
+  if(tcase.count("set-var")) {
+    vn.clear();
+    int gvar_case = 0;
+    while(tcase["set-var"].count(std::to_string(gvar_case))){
+      vn.push_back(tcase["set-var"][std::to_string(gvar_case)].get<std::string>());
+      gvar_case++;
+    }
   } else
     vn.clear();
 
@@ -331,7 +336,7 @@ char ** argv_conv(const std::string &cmd, const str_list_t &args) {
 bool run_tests(std::list<std::string> cases) {
   std::string prog, cmd;
   str_llist_t alist;
-  std::string gvar;
+  str_list_t gvar;
   std::set<int> expect_results, retry_results, rvs;
   while(!cases.empty()) {
     auto cn = cases.front();
@@ -358,21 +363,22 @@ bool run_tests(std::list<std::string> cases) {
           rv = run_cmd(argv_conv(cmd, arg));
 
           // record run-time parameter
-          if(!gvar.empty() && rv >= 32 && rv < 64) { // successfully find a run-time parameter
-            std::cerr << "set runtime variable " << gvar << " to " << rv - 32 << std::endl;
-            var_db[gvar] = rv-32; dump_json(var_db, "variables.json", false);
+          if(gvar.size() == 1 && rv >= 32 && rv < 64) { // successfully find a run-time parameter
+            std::cerr << "set runtime variable " << gvar.front() << " to " << rv - 32 << std::endl;
+            var_db[gvar.front()] = rv-32; dump_json(var_db, "variables.json", false);
             rv = 0;
           }
 
           if(!gvar.empty() && rv == 64) { // a run-time parameter recorded in atmp file
             std::ifstream tmpf(temp_file_name(cmd, arg));
             if(tmpf.good()) {
-              int value;
-              tmpf >> value;
-              var_db[gvar] = value; dump_json(var_db, "variables.json", false);
-              tmpf.close();
+              for(auto i =  gvar.begin(); i != gvar.end(); i++){
+                int value;tmpf >> value;
+                var_db[*i] = value; dump_json(var_db, "variables.json", false);
+                std::cerr << "set runtime variable " << *i << " to " << value << " by reading " << temp_file_name(cmd, arg) << std::endl;
+              }
               rv = 0;
-              std::cerr << "set runtime variable " << gvar << " to " << value << " by reading " << temp_file_name(cmd, arg) << std::endl;
+              tmpf.close();
             }
           }
 

--- a/script/get_aarch64_func_inst.sh
+++ b/script/get_aarch64_func_inst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_aarch64_func_inst.sh proc_name func_name file_name
+#Example: ./get_aarch64_func_inst.sh ./test/acc-read-func helper func_helper.tmp
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" > "$3"

--- a/script/get_x86_func_inst.sh
+++ b/script/get_x86_func_inst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_x86_func_inst.sh proc_name func_name file_name
+#Example: ./get_x86_func_inst.sh ./test/acc-read-func helper func_helper.tmp
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" > "$3"


### PR DESCRIPTION
…lated functions
* modify run-test.cpp and temp_file.cpp to store a serises of vars rather than only one var, in read-func test the vars are code_num, code_mask, offset.
*  split text processing part to shell code in ./script, which is simpler and more easily to read.
* add get-static-funcinfo test to fetch read-func's static info, and this feature need run-test to build read-func before get-static-funcinfo, paradoxically, get-static-funcinfo is required by read-func.So I choose this method that make all test before run it in another PR #35. Maybe adding a property "require_make" for one test in configure.json is better, I currently use this temp patch for test.
* It seems work correctly in x86 and arm, shell code(text processing) can run in x86 and both arm. and C++ extract inst code works correctly.  