### PR TITLE
chore: clang option error when enabled asan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,14 @@ ifdef enable_stack_clash_protection
 endif
 
 ifdef enable_address_sanitizer
-  CXXFLAGS += -fsanitize=address --param=asan-stack=1
+  CXXFLAGS += -fsanitize=address
 ifeq ($(CXX),clang++)
+  LDFLAGS  += -static-libsan
+else ifeq($(CXX),c++)
   LDFLAGS  += -static-libsan
 else
   LDFLAGS  += -static-libasan
+  CXXFLAGS += --param=asan-stack=1
 endif
 endif
 


### PR DESCRIPTION
clang default CXX is c++, add this case in Makefile.
--param=asan-stack is default in clang asan, and clang yield warning about it, so only add it to CXXFLAG when gcc env.