### PR TITLE
fix: read-func false-failed when Asan enabled

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -596,8 +596,7 @@
         "expect-results": { "1": "ASLR enabled."}
     },
     "acc-read-func": {
-        "require": { "0": [ [ "acc-check-CET" ] ] },
-        "arguments": {"0": ["1", "-vcet-enabled"] }
+        "arguments": {"0": ["1"] }
     },
     "acc-get-ra-offset-v-p-g0": {
         "program": "acc-get-ra-offset",

--- a/lib/aarch64/assembly.cpp
+++ b/lib/aarch64/assembly.cpp
@@ -134,3 +134,9 @@ void replace_got_func(void **fake, void *got) {
 
 }
 
+int run_dump_cmd(const std::string& procname,
+                 const std::string& funcname, const std::string& filename){
+  std::string cmd = "./script/get_aarch64_func_inst.sh " + procname + " "
+                    + funcname + " " + filename;
+  return system(cmd.c_str());
+}

--- a/lib/include/assembly.hpp
+++ b/lib/include/assembly.hpp
@@ -3,6 +3,7 @@
 #ifndef ASSEMBLY_HPP_INCLUDED
 #define ASSEMBLY_HPP_INCLUDED
 
+#include <string>
 #include "include/gcc_builtin.hpp"
 
 // a barrier to stop compiler from reorder memory operations
@@ -41,5 +42,7 @@
 
 extern void get_got_func(void **gotp, void *label, int cet);
 extern void replace_got_func(void **fake, void *got);
+extern int run_dump_cmd(const std::string& procname,const std::string& funcname,
+                       const std::string& filename);
 
 #endif // ASSEMBLY_HPP_INCLUDED

--- a/lib/include/get_static_funcinfo.hpp
+++ b/lib/include/get_static_funcinfo.hpp
@@ -1,0 +1,8 @@
+#ifndef CSB_GET_STATIC_FUNCINFO_HPP
+#define CSB_GET_STATIC_FUNCINFO_HPP
+
+#include <string>
+extern int get_func_nth_inst(std::string prog, std::string func, 
+                      std::string file, int nth);
+
+#endif

--- a/lib/tool/get_static_funcinfo.cpp
+++ b/lib/tool/get_static_funcinfo.cpp
@@ -1,0 +1,44 @@
+#include "include/assembly.hpp"
+#include "include/temp_file.hpp"
+#include <fstream>
+#include <sstream>
+
+/* Get func's nth inst-info of prog and output it to ofile*/
+int get_func_nth_inst(std::string prog, std::string func, 
+                      std::string ofile, int nth){
+  
+  unsigned int code_num = 0;
+  unsigned int code_mask = 0;
+  unsigned int inst_byte_offset = 0;
+
+  std::string dump_file = "./test/get_func_nth_inst.tmp";
+  if(run_dump_cmd(prog,func,dump_file) == 0){//call arch related shell code
+    std::ifstream itmpf(dump_file);
+    if(itmpf.good()){
+      std::string line;
+      int tmp_num, bytes_num = 0;
+      while(nth--){
+        std::getline(itmpf,line);
+        std::istringstream sline(line);
+        if(nth != 0){//handle 1-(n-1)th inst, count these inst byte num
+          while(sline >> std::hex >> tmp_num) inst_byte_offset++;
+        }else{//handle inst opcode mode is the little endian 
+          while(sline >> std::hex >> tmp_num){
+            tmp_num <<= bytes_num;
+            code_num |= tmp_num;code_mask |= (0xff << bytes_num);
+            bytes_num += 8;
+          }
+        }
+      }
+      std::ofstream otmpf(ofile);
+      if(otmpf.good()){
+        otmpf << code_num << "\n";
+        otmpf << code_mask << "\n";
+        otmpf << inst_byte_offset;
+        otmpf.close();
+        return 0;
+      }
+    }
+  }
+  return -1;
+}

--- a/lib/x86_64/assembly.cpp
+++ b/lib/x86_64/assembly.cpp
@@ -43,4 +43,9 @@ void replace_got_func(void **fake, void *got) {
   );
 }
 
-
+int run_dump_cmd(const std::string& procname,
+                 const std::string& funcname, const std::string& filename){
+  std::string cmd = "./script/get_x86_func_inst.sh " + procname + " "
+                    + funcname + " " + filename;
+  return system(cmd.c_str());
+}

--- a/script/get_aarch64_func_inst.sh
+++ b/script/get_aarch64_func_inst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_aarch64_func_inst.sh proc_name func_name file_name
+#Example: ./get_aarch64_func_inst.sh ./test/acc-read-func helper func_helper.tmp
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" > "$3"

--- a/script/get_x86_func_inst.sh
+++ b/script/get_x86_func_inst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_x86_func_inst.sh proc_name func_name file_name
+#Example: ./get_x86_func_inst.sh ./test/acc-read-func helper func_helper.tmp
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" > "$3"


### PR DESCRIPTION
     * mv get-static-funcinfo to lib
     * mv text process function to arch related shell code
     * read-func.cpp read funcinfo from tempfile and hasn't require has-CET check
     * add tools target for read-func building, add conditional judge in makefile static mode acc target