### PR TITLE
chore: clang option error when enabled asan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,14 @@ ifdef enable_stack_clash_protection
 endif
 
 ifdef enable_address_sanitizer
-  CXXFLAGS += -fsanitize=address --param=asan-stack=1
+  CXXFLAGS += -fsanitize=address
 ifeq ($(CXX),clang++)
+  LDFLAGS  += -static-libsan
+else ifeq ($(CXX),c++)
   LDFLAGS  += -static-libsan
 else
   LDFLAGS  += -static-libasan
+  CXXFLAGS += --param=asan-stack=1
 endif
 endif
 


### PR DESCRIPTION
* ifeq should be in the same line with else
* ifeq should has a space blabk between brace