### PR TITLE
chore: remove useless statement about assembly

### DIFF
--- a/acc/check-CET.cpp
+++ b/acc/check-CET.cpp
@@ -5,7 +5,7 @@ int main(int argc, char* argv[])
   void *goto_label = &&GOTO_SITE;
   unsigned int instr = *(unsigned int *)(goto_label);
   if(argv[1][0] - '0' == -1) goto *goto_label;   // impossible to happen
-  COMPILER_BARRIER;
+  mbarrier;
  GOTO_SITE:
   // assuming only Intel x86_64 would add a endbr64 instruction here
   if((instr & 0xffffffff) == 0xfa1e0ff3) return 32+1;

--- a/acc/get-ra-offset.cpp
+++ b/acc/get-ra-offset.cpp
@@ -63,7 +63,7 @@ int test_##FT(int v) {             \
   void *ra_label = &&RA_POS;       \
   if(v == -1) goto *ra_label;      \
   helper_##FT(ra_label);           \
-  COMPILER_BARRIER;                \
+  mbarrier;                        \
  RA_POS:                           \
   if(gvar() < 0) return 1;         \
   return gvar() + 32;              \

--- a/acc/read-GOT.cpp
+++ b/acc/read-GOT.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
   if(cet_enabled == -1) goto *rand_label;   // impossible to happen
 
   get_got_func(&got, rand_label, cet_enabled);
-  COMPILER_BARRIER;
+  mbarrier;
  RAND_CALL:
   rand();
   mbarrier;

--- a/acc/read-func.cpp
+++ b/acc/read-func.cpp
@@ -23,10 +23,10 @@
 int FORCE_NOINLINE helper(int var, int cet, int sum) {
   unsigned int *code = (unsigned int *)(&&CHECK_POS);
   unsigned int *code_cet = code + cet;
-  COMPILER_BARRIER;
+  mbarrier;
  CHECK_POS:
   var += cet;
-  COMPILER_BARRIER;
+  mbarrier;
   return (var == sum &&
           (
            ((*code    ) & READ_FUNC_MASK) == READ_FUNC_CODE ||

--- a/cfi/call-wrong-type-arg-int2double-func.cpp
+++ b/cfi/call-wrong-type-arg-int2double-func.cpp
@@ -15,7 +15,7 @@ int main()
 #else
   arch_int_t *i = (arch_int_t *)(&d);
   *i = -1;  // use the memory as way to pass an int to the double arguemnt
-  COMPILER_BARRIER;
+  mbarrier;
   helper(d);
   exit(gvar());
 #endif

--- a/cfi/code-injection.cpp
+++ b/cfi/code-injection.cpp
@@ -21,7 +21,7 @@ void FORCE_NOINLINE return_helper(void *p) {
 
 void FORCE_NOINLINE call_helper(func_t f) {
   gvar_init(2);
-  COMPILER_BARRIER;
+  mbarrier;
   f();
 }
 

--- a/cfi/return-to-libc.cpp
+++ b/cfi/return-to-libc.cpp
@@ -13,7 +13,7 @@ void FORCE_NOINLINE helper(void *label) {
    */
   offset = rand();
   gvar_init(3);
-  COMPILER_BARRIER;
+  mbarrier;
   PASS_INT_ARG0_IMM(0);
 }
 

--- a/cfi/return-to-non-call-site.cpp
+++ b/cfi/return-to-non-call-site.cpp
@@ -5,7 +5,7 @@ volatile arch_int_t offset;
 
 void FORCE_NOINLINE helper(void *label) {
   gvar_init(3);
-  COMPILER_BARRIER;
+  mbarrier;
   MOD_STACK_DAT(label, offset);
   /* HiFive Unmatched, GCC 11.2.0
    * Make sure offset is modified as otherwise

--- a/cfi/return-to-wrong-call-site-within-static-analysis.cpp
+++ b/cfi/return-to-wrong-call-site-within-static-analysis.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
 
   // call a function but illegally return
   helper(ret_label);
-  COMPILER_BARRIER;
+  mbarrier;
   // the elligal return site
  RET_POS:
   if(gvar() < 0) exit(32 - gvar());

--- a/cfi/return-to-wrong-call-site.cpp
+++ b/cfi/return-to-wrong-call-site.cpp
@@ -5,7 +5,7 @@ volatile arch_int_t offset;
 
 void FORCE_NOINLINE helper(void *label) {
   gvar_init(3);
-  COMPILER_BARRIER;
+  mbarrier;
   MOD_STACK_DAT(label, offset);
   /* HiFive Unmatched, GCC 11.2.0
    * Make sure offset is modified as otherwise
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
   // call a function but illegally return
   helper(ret_label);
   helper2();// failed if runs here
-  COMPILER_BARRIER;
+  mbarrier;
   // the elligal return site
  RET_POS:
   exit(gvar());

--- a/cpi/modify-GOT.cpp
+++ b/cpi/modify-GOT.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
   if(cet_enabled == -1) goto *rand_label;   // impossible to happen
 
   get_got_func(&got, rand_label, cet_enabled);
-  COMPILER_BARRIER;
+  mbarrier;
  RAND_CALL:
   rand();
   mbarrier;

--- a/lib/aarch64/assembly.hpp
+++ b/lib/aarch64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0b000020
-#define READ_FUNC_MASK 0xffffffe0
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/include/assembly.hpp
+++ b/lib/include/assembly.hpp
@@ -5,9 +5,6 @@
 
 #include "include/gcc_builtin.hpp"
 
-// a barrier to stop compiler from reorder memory operations
-#define COMPILER_BARRIER asm volatile("" : : : "memory")
-
 // detect ISA
 #ifdef __x86_64
   #define CSB_X86_64

--- a/lib/include/gcc_builtin.hpp
+++ b/lib/include/gcc_builtin.hpp
@@ -4,6 +4,7 @@
 // make a function incline/non-inline
 #define FORCE_INLINE __attribute__((always_inline)) inline
 #define FORCE_NOINLINE __attribute__((noinline))
+// a barrier to stop compiler from reorder memory operations
 #define mbarrier asm volatile("": : :"memory")
 
 // code/data alignment

--- a/lib/riscv64/assembly.hpp
+++ b/lib/riscv64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x00009d2d
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/x86_64/assembly.hpp
+++ b/lib/x86_64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // x86_64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0000f701
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \


### PR DESCRIPTION
       * remove repeated memory barrier macro definition in assembly.hpp and builtin.hpp
       * remove machine code macro definition for read-func.cpp