### PR TITLE
feat: add the support for r/w an array of global var

### DIFF
--- a/lib/common/temp_file.cpp
+++ b/lib/common/temp_file.cpp
@@ -3,7 +3,7 @@
 
 std::string temp_file_name(const std::string& cmd, const std::list<std::string>& glist) {
   std::string fn = cmd;
-  for(auto const g:glist) fn += "_" + g;
+  for(auto const &g:glist) fn += "_" + g;
   fn += ".tmp";
   return fn;
 }
@@ -16,8 +16,8 @@ void write_to_temp_file(int var, int argc, char **argv) {
   }
   fn += ".tmp";
 
-  std::ofstream f(fn);
-  f << var;
+  std::ofstream f(fn,std::ofstream::app);
+  f << var << "\n";
   f.close();
 }
 


### PR DESCRIPTION
      * chore: add &g:glist in tmp_file.cpp to avoid warning.
      * The previous method of transferring global var through
        tmp files can only transfer a single int parameter.
        After the improvement, multiple int type parameters can be transferred