### PR TITLE
fix: read-func false-failed when Asan enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifeq ($(ARCH), arm64)
   ARCH := aarch64
 endif
 
+# why do you need do this?
 export ARCH
 
 ifeq ($(OSType), Darwin)
@@ -187,7 +188,7 @@ $(mts-cpps-prep): %.prep:%
 	$(CXX) -E $(CXXFLAGS) $< > $@
 
 # do not try to complicate this part
-$(acc-tests): $(test-path)/acc-%:$(acc-path)/%.cpp $(common_objects) $(extra_tools)
+$(acc-tests): $(test-path)/acc-%:$(acc-path)/%.cpp $(common_objects)
 	$(CXX) $(CXXFLAGS) $< $(common_objects) -o $@ $(LDFLAGS)
 
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ ifeq ($(ARCH), arm64)
   ARCH := aarch64
 endif
 
+export ARCH
+
 ifeq ($(OSType), Darwin)
   CPU_INFO := $(shell sysctl -n machdep.cpu.brand_string)
 else
@@ -121,7 +123,8 @@ sec-tests-dump = $(addsuffix .dump, $(sec-tests))
 sec-tests-prep := $(mss-cpps-prep) $(mts-cpps-prep) $(acc-cpps-prep) $(cpi-cpps-prep) $(cfi-cpps-prep)
 
 headers := $(wildcard $(base)/lib/include/*.hpp) $(wildcard $(base)/lib/$(ARCH)/*.hpp)
-extra_objects := $(base)/lib/common/global_var.o $(base)/lib/common/signal.o $(base)/lib/common/temp_file.o $(addprefix $(base)/lib/$(ARCH)/, assembly.o)
+common_objects := $(base)/lib/common/global_var.o $(base)/lib/common/signal.o $(base)/lib/common/temp_file.o $(addprefix $(base)/lib/$(ARCH)/, assembly.o)
+extra_tools := $(base)/lib/tool/get_static_funcinfo.o
 
 # compile targets
 
@@ -154,50 +157,57 @@ libcfi.so: $(base)/lib/common/cfi.cpp  $(base)/lib/include/cfi.hpp
 
 rubbish += $(test-path)/libcfi.so
 
-$(extra_objects): %.o : %.cpp $(headers)
+$(common_objects): %.o : %.cpp $(headers)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-rubbish += $(extra_objects)
+$(extra_tools): %.o : %.cpp $(headers)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+rubbish += $(common_objects) $(extra_tools)
 
 $(base)/lib/common/mss.o: %.o : %.cpp $(base)/lib/include/mss.hpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 rubbish += $(base)/lib/common/mss.o
 
-$(mss-tests): $(test-path)/mss-%:$(mss-path)/%.cpp $(extra_objects) $(headers) $(base)/lib/common/mss.o
-	$(CXX) $(CXXFLAGS) $< $(extra_objects) $(base)/lib/common/mss.o -o $@ $(LDFLAGS)
+$(mss-tests): $(test-path)/mss-%:$(mss-path)/%.cpp $(common_objects) $(headers) $(base)/lib/common/mss.o
+	$(CXX) $(CXXFLAGS) $< $(common_objects) $(base)/lib/common/mss.o -o $@ $(LDFLAGS)
 
 rubbish += $(mss-tests)
 
 $(mss-cpps-prep): %.prep:%
 	$(CXX) -E $(CXXFLAGS) $< > $@
 
-$(mts-tests): $(test-path)/mts-%:$(mts-path)/%.cpp $(extra_objects) $(base)/lib/common/mss.o
-	$(CXX) $(CXXFLAGS) $< $(extra_objects) $(base)/lib/common/mss.o -o $@ $(LDFLAGS)
+$(mts-tests): $(test-path)/mts-%:$(mts-path)/%.cpp $(common_objects) $(base)/lib/common/mss.o
+	$(CXX) $(CXXFLAGS) $< $(common_objects) $(base)/lib/common/mss.o -o $@ $(LDFLAGS)
 
 rubbish += $(mts-tests)
 
 $(mts-cpps-prep): %.prep:%
 	$(CXX) -E $(CXXFLAGS) $< > $@
 
-$(acc-tests): $(test-path)/acc-%:$(acc-path)/%.cpp $(extra_objects)
-	$(CXX) $(CXXFLAGS) $< $(extra_objects) -o $@ $(LDFLAGS)
+$(acc-tests): $(test-path)/acc-%:$(acc-path)/%.cpp $(common_objects) $(extra_tools)
+	if [ $* = read-func ]; then $(CXX) $(CXXFLAGS) $< $(common_objects) $(extra_tools) -o $@ $(LDFLAGS);\
+	    if [ $(ARCH) = aarch64 ]; then echo call aarch64 objdump shell-code; ./script/get_aarch64_func_inst.sh ./test/acc-read-func helper ./test/funcopcode.tmp;\
+		elif [ $(ARCH) = x86_64 ]; then echo call x86_64 objdump shell-code; ./script/get_x86_func_inst.sh ./test/acc-read-func helper ./test/funcopcode.tmp;\
+		else echo call x86_64 objdump shell-code; ./script/get_x86_func_inst.sh ./test/acc-read-func helper ./test/funcopcode.tmp;fi;\
+    else $(CXX) $(CXXFLAGS) $< $(common_objects) -o $@ $(LDFLAGS);fi
 
 rubbish += $(acc-tests)
 
 $(acc-cpps-prep): %.prep:%
 	$(CXX) -E $(CXXFLAGS) $< > $@
 
-$(cpi-tests): $(test-path)/cpi-%:$(cpi-path)/%.cpp $(extra_objects) libcfi.so $(headers)
-	$(CXX) $(CXXFLAGS) $< $(extra_objects) -L. -Wl,-rpath,. -o $@ -lcfi $(LDFLAGS)
+$(cpi-tests): $(test-path)/cpi-%:$(cpi-path)/%.cpp $(common_objects) libcfi.so $(headers)
+	$(CXX) $(CXXFLAGS) $< $(common_objects) -L. -Wl,-rpath,. -o $@ -lcfi $(LDFLAGS)
 
 rubbish += $(cpi-tests)
 
 $(cpi-cpps-prep): %.prep:%
 	$(CXX) -E $(CXXFLAGS) $< > $@
 
-$(cfi-tests): $(test-path)/cfi-%:$(cfi-path)/%.cpp $(extra_objects) libcfi.so $(headers)
-	$(CXX) $(CXXFLAGS) $< $(extra_objects) -L. -Wl,-rpath,. -o $@ -lcfi $(LDFLAGS)
+$(cfi-tests): $(test-path)/cfi-%:$(cfi-path)/%.cpp $(common_objects) libcfi.so $(headers)
+	$(CXX) $(CXXFLAGS) $< $(common_objects) -L. -Wl,-rpath,. -o $@ -lcfi $(LDFLAGS)
 
 rubbish += $(cfi-tests)
 

--- a/acc/read-func.cpp
+++ b/acc/read-func.cpp
@@ -1,5 +1,10 @@
 #include "include/assembly.hpp"
+#include "include/get_static_funcinfo.hpp"
+#include <fstream>
 
+unsigned int code_num    = 0;
+unsigned int code_mask   = 0;
+unsigned int inst_byte_offset = 0;
 /*
  * If a local variable is modified by an embedded assembly,
  * it might be removed by Clang 12 on Mac M1.
@@ -20,24 +25,22 @@
  * Relax the check by reading both locations.
  */
 
-int FORCE_NOINLINE helper(int var, int cet, int sum) {
-  unsigned int *code = (unsigned int *)(&&CHECK_POS);
-  unsigned int *code_cet = code + cet;
-  COMPILER_BARRIER;
- CHECK_POS:
-  var += cet;
-  COMPILER_BARRIER;
-  return (var == sum &&
-          (
-           ((*code    ) & READ_FUNC_MASK) == READ_FUNC_CODE ||
-           ((*code_cet) & READ_FUNC_MASK) == READ_FUNC_CODE
-          )
-         )
-    ? 0 : 1;
+int FORCE_NOINLINE helper(int var) {
+  unsigned char *code = (unsigned char *)(&helper);
+  code += inst_byte_offset;
+  return ((*(unsigned int*)code) & code_mask) == code_num
+         ? 0 : 1;
 }
 
 int main(int argc, char* argv[]) {
   int var = argv[1][0] - '0';
-  int cet = argv[2][0] - '0';
-  return helper(var, cet, var+cet);
+  get_func_nth_inst(5);
+  std::ifstream itmpf("./test/funcinfo.tmp");
+  if(itmpf.good()){
+    return helper(var);
+    itmpf >> code_num;
+    itmpf >> code_mask;
+    itmpf >> inst_byte_offset;
+  }
+  return 2;
 }

--- a/acc/read-func.cpp
+++ b/acc/read-func.cpp
@@ -1,5 +1,4 @@
 #include "include/assembly.hpp"
-#include "include/get_static_funcinfo.hpp"
 #include <fstream>
 
 unsigned int code_num    = 0;
@@ -25,22 +24,22 @@ unsigned int inst_byte_offset = 0;
  * Relax the check by reading both locations.
  */
 
-int FORCE_NOINLINE helper(int var) {
+int FORCE_NOINLINE helper() {
   unsigned char *code = (unsigned char *)(&helper);
   code += inst_byte_offset;
   return ((*(unsigned int*)code) & code_mask) == code_num
          ? 0 : 1;
 }
 
+// move the get nth opcode out of the test all together!
 int main(int argc, char* argv[]) {
-  int var = argv[1][0] - '0';
-  get_func_nth_inst(5);
-  std::ifstream itmpf("./test/funcinfo.tmp");
+  std::string fn(argv[1]);
+  std::ifstream itmpf(fn);
   if(itmpf.good()){
-    return helper(var);
     itmpf >> code_num;
     itmpf >> code_mask;
     itmpf >> inst_byte_offset;
+    return helper(var);
   }
   return 2;
 }

--- a/configure.json
+++ b/configure.json
@@ -596,7 +596,8 @@
         "expect-results": { "1": "ASLR enabled."}
     },
     "acc-read-func": {
-        "arguments": {"0": ["1"] }
+        "program": "acc-read-func.gen",
+        "arguments": {"0": ["test/acc-read-func-func-info.tmp"] }
     },
     "acc-get-ra-offset-v-p-g0": {
         "program": "acc-get-ra-offset",

--- a/configure.json
+++ b/configure.json
@@ -596,8 +596,7 @@
         "expect-results": { "1": "ASLR enabled."}
     },
     "acc-read-func": {
-        "require": { "0": [ [ "acc-check-CET" ] ] },
-        "arguments": {"0": ["1", "-vcet-enabled"] }
+        "arguments": {"0": ["1"] }
     },
     "acc-get-ra-offset-v-p-g0": {
         "program": "acc-get-ra-offset",

--- a/lib/include/get_static_funcinfo.hpp
+++ b/lib/include/get_static_funcinfo.hpp
@@ -1,0 +1,7 @@
+#ifndef CSB_GET_STATIC_FUNCINFO_HPP
+#define CSB_GET_STATIC_FUNCINFO_HPP
+
+#include <string>
+extern int get_func_nth_inst(int nth);
+
+#endif

--- a/lib/tool/get_static_funcinfo.cpp
+++ b/lib/tool/get_static_funcinfo.cpp
@@ -1,0 +1,40 @@
+#include "include/assembly.hpp"
+#include "include/temp_file.hpp"
+#include <fstream>
+#include <sstream>
+
+/* Get func's nth inst-info of prog and output it to ofile*/
+int get_func_nth_inst(int nth){
+
+  unsigned int code_num = 0;
+  unsigned int code_mask = 0;
+  unsigned int inst_byte_offset = 0;
+
+  std::ifstream itmpf("./test/funcopcode.tmp");
+  if(itmpf.good()){
+    std::string line;
+    int tmp_num, bytes_num = 0;
+    while(nth--){
+      std::getline(itmpf,line);
+      std::istringstream sline(line);
+      if(nth != 0){//handle 1-(n-1)th inst, count these inst byte num
+        while(sline >> std::hex >> tmp_num) inst_byte_offset++;
+      }else{//handle inst opcode mode is the little endian
+        while(sline >> std::hex >> tmp_num){
+          tmp_num <<= bytes_num;
+          code_num |= tmp_num;code_mask |= (0xff << bytes_num);
+          bytes_num += 8;
+        }
+      }
+    }
+    std::ofstream otmpf("./test/funcinfo.tmp");
+    if(otmpf.good()){
+      otmpf << code_num << "\n";
+      otmpf << code_mask << "\n";
+      otmpf << inst_byte_offset << "\n";
+      otmpf.close();
+      return 0;
+    }
+  }
+  return -1;
+}

--- a/script/get_aarch64_func_inst.sh
+++ b/script/get_aarch64_func_inst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_aarch64_func_inst.sh proc_name func_name file_name
+#Example: ./get_aarch64_func_inst.sh ./test/acc-read-func helper func_helper.tmp
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" > "$3"

--- a/script/get_x86_func_inst.sh
+++ b/script/get_x86_func_inst.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_x86_func_inst.sh proc_name func_name file_name
+#Example: ./get_x86_func_inst.sh ./test/acc-read-func helper func_helper.tmp
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" > "$3"


### PR DESCRIPTION
     * mv get-static-funcinfo to lib
     * mv text process function to arch related shell code
     * read-func.cpp read funcinfo from tempfile and hasn't require has-CET check
     * add tools target for read-func building and conditional judge(arch shell code) in makefile static mode acc target
     * avoid to add unportable code in assembly.cpp