### PR TITLE
chore: remove useless statement about assembly

### DIFF
--- a/acc/read-GOT.cpp
+++ b/acc/read-GOT.cpp
@@ -17,6 +17,6 @@ int main(int argc, char* argv[])
   COMPILER_BARRIER;
  RAND_CALL:
   rand();
-  mbarrier;
+  COMPILER_BARRIER;
   return 0 != *(uintptr_t *)(got) ? 0 : 1;
 }

--- a/cpi/modify-GOT.cpp
+++ b/cpi/modify-GOT.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
   COMPILER_BARRIER;
  RAND_CALL:
   rand();
-  mbarrier;
+  COMPILER_BARRIER;
 
   begin_catch_exception(got, SEGV_ACCERR);
   replace_got_func((void **)helper, got);

--- a/lib/aarch64/assembly.hpp
+++ b/lib/aarch64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0b000020
-#define READ_FUNC_MASK 0xffffffe0
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/include/assembly.hpp
+++ b/lib/include/assembly.hpp
@@ -5,9 +5,6 @@
 
 #include "include/gcc_builtin.hpp"
 
-// a barrier to stop compiler from reorder memory operations
-#define COMPILER_BARRIER asm volatile("" : : : "memory")
-
 // detect ISA
 #ifdef __x86_64
   #define CSB_X86_64

--- a/lib/include/gcc_builtin.hpp
+++ b/lib/include/gcc_builtin.hpp
@@ -4,7 +4,9 @@
 // make a function incline/non-inline
 #define FORCE_INLINE __attribute__((always_inline)) inline
 #define FORCE_NOINLINE __attribute__((noinline))
-#define mbarrier asm volatile("": : :"memory")
+
+// a barrier to stop compiler from reorder memory operations
+#define COMPILER_BARRIER asm volatile("" : : : "memory")
 
 // code/data alignment
 #define ALIGN(NByte) __attribute__ ((aligned (NByte)))

--- a/lib/riscv64/assembly.hpp
+++ b/lib/riscv64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // riscv64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x00009d2d
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/x86_64/assembly.hpp
+++ b/lib/x86_64/assembly.hpp
@@ -1,10 +1,6 @@
 // assembly helper functions
 // x86_64
 
-// special macros for acc-read-func
-#define READ_FUNC_CODE 0x0000f701
-#define READ_FUNC_MASK 0x0000ffff
-
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \


### PR DESCRIPTION
       * remove repeated memory barrier macro definition(mbarrier) in assembly.hpp and builtin.hpp
       * remove machine code macro definition for read-func.cpp