### PR TITLE
fix: read-func false-failed when Asan enabled(pure shell code)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,6 @@ acc-cpps  = $(wildcard $(acc-path)/*.cpp)
 acc-tests = $(addprefix $(test-path)/acc-, $(basename $(notdir $(acc-cpps))))
 acc-cpps-prep = $(addsuffix .prep, $(acc-cpps))
 
-# this target is for forcing the generation of special acc test target
-acc-gen   = $(addsuffix .gen, $(acc-tests))
-.PHONY: $(acc-gen)
-
 cpi-path  = $(base)/cpi
 cpi-cpps  = $(wildcard $(cpi-path)/*.cpp)
 cpi-tests = $(addprefix $(test-path)/cpi-, $(basename $(notdir $(cpi-cpps))))
@@ -189,14 +185,14 @@ rubbish += $(mts-tests)
 $(mts-cpps-prep): %.prep:%
 	$(CXX) -E $(CXXFLAGS) $< > $@
 
-$(acc-tests): $(test-path)/acc-%:$(acc-path)/%.cpp $(test-path)/acc-%.gen $(extra_objects) 
+$(acc-tests): $(test-path)/acc-%:$(acc-path)/%.cpp $(extra_objects)
 	$(CXX) $(CXXFLAGS) $< $(extra_objects) -o $@ $(LDFLAGS)
 
-$(test-path)/acc-read-func-func-opcode.tmp: $(func-opcode-gen)
-	$(CXX) $(CXXFLAGS) $(acc-path)/read-func.cpp $(extra_objects) -o $(test-path)/acc-read-func $(LDFLAGS)
-	$^ $(test-path)/acc-read-func helper 8 $@
+$(test-path)/acc-read-func-func-opcode.tmp: $(func-opcode-gen) $(test-path)/acc-read-func
+	$^ helper 8 $@
 
-$(test-path)/acc-read-func.gen: $(test-path)/acc-read-func-func-opcode.tmp
+$(test-path)/acc-read-func.gen: %.gen:% $(test-path)/acc-read-func-func-opcode.tmp
+	cp $< $@
 
 rubbish += $(acc-tests)
 
@@ -232,7 +228,7 @@ prep: $(sec-tests-prep)
 rubbish += $(sec-tests-prep)
 
 clean:
-	-rm $(rubbish) *.tmp $(test-path)/*.tmp > /dev/null 2>&1
+	-rm $(rubbish) *.tmp $(test-path)/*.tmp $(test-path)/*.gen > /dev/null 2>&1
 
 .PHONY: clean run dump prep
 

--- a/acc/read-func.cpp
+++ b/acc/read-func.cpp
@@ -1,4 +1,7 @@
 #include "include/assembly.hpp"
+#include <fstream>
+
+unsigned long long code_num = 0;
 
 /*
  * If a local variable is modified by an embedded assembly,
@@ -20,24 +23,18 @@
  * Relax the check by reading both locations.
  */
 
-int FORCE_NOINLINE helper(int var, int cet, int sum) {
-  unsigned int *code = (unsigned int *)(&&CHECK_POS);
-  unsigned int *code_cet = code + cet;
-  COMPILER_BARRIER;
- CHECK_POS:
-  var += cet;
-  COMPILER_BARRIER;
-  return (var == sum &&
-          (
-           ((*code    ) & READ_FUNC_MASK) == READ_FUNC_CODE ||
-           ((*code_cet) & READ_FUNC_MASK) == READ_FUNC_CODE
-          )
-         )
-    ? 0 : 1;
+int FORCE_NOINLINE helper() {
+  unsigned long long *code = (unsigned long long *)(&helper);
+  return (*code) == code_num
+         ? 0 : 1;
 }
 
 int main(int argc, char* argv[]) {
-  int var = argv[1][0] - '0';
-  int cet = argv[2][0] - '0';
-  return helper(var, cet, var+cet);
+
+  std::ifstream itmpf(argv[1]);
+  if(itmpf.good()){
+    itmpf >> std::hex >> code_num;
+    return helper();
+  }
+  return 2;
 }

--- a/configure.json
+++ b/configure.json
@@ -596,8 +596,7 @@
         "expect-results": { "1": "ASLR enabled."}
     },
     "acc-read-func": {
-        "require": { "0": [ [ "acc-check-CET" ] ] },
-        "arguments": {"0": ["1", "-vcet-enabled"] }
+        "arguments": {"0": ["./test/acc-read-func-func-opcode.tmp"] }
     },
     "acc-get-ra-offset-v-p-g0": {
         "program": "acc-get-ra-offset",

--- a/configure.json
+++ b/configure.json
@@ -596,6 +596,7 @@
         "expect-results": { "1": "ASLR enabled."}
     },
     "acc-read-func": {
+        "program": "acc-read-func.gen",
         "arguments": {"0": ["./test/acc-read-func-func-opcode.tmp"] }
     },
     "acc-get-ra-offset-v-p-g0": {

--- a/script/get_aarch64_func_inst.sh
+++ b/script/get_aarch64_func_inst.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_aarch64_func_inst.sh proc_name func_name byte_nums file_name
+#Example: ./get_aarch64_func_inst.sh ./test/acc-read-func helper 8 func_helper.tmp
+byte_nums=$3
+
+reverse_word_order(){
+    local result=
+    for word in $@; do
+        result="$word $result"
+    done
+    echo "$result" 
+}
+
+get_dw_opcode(){
+    local result=
+    local count=0
+    for word in $@; do
+        if [ $count -eq $byte_nums ]; then
+            break;
+        fi
+        result="$result $word"
+        count=$[$count+1]
+    done
+    echo "$result"
+}
+
+delete_blank(){
+    local result=
+    for word in $@; do
+        result="$result$word"
+    done
+    echo "$result"
+}
+
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+opcode_oneline=$(objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" | xargs)
+opcode_be_dw=$(get_dw_opcode "$opcode_oneline")
+opcode_le_dw=$(reverse_word_order "$opcode_be_dw")
+opcode_unsignedlonglong=$(delete_blank "$opcode_le_dw")
+echo $opcode_unsignedlonglong > $4

--- a/script/get_aarch64_func_inst.sh
+++ b/script/get_aarch64_func_inst.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -u
-set -e
-set -x
+#set -u
+#set -e
+#set -x
 #Usage:   ./get_aarch64_func_inst.sh proc_name func_name byte_nums file_name
 #Example: ./get_aarch64_func_inst.sh ./test/acc-read-func helper 8 func_helper.tmp
 byte_nums=$3

--- a/script/get_x86_func_inst.sh
+++ b/script/get_x86_func_inst.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_x86_func_inst.sh proc_name func_name byte_nums file_name
+#Example: ./get_x86_func_inst.sh ./test/acc-read-func helper 8 func_helper.tmp
+byte_nums=$3
+
+reverse_word_order(){
+    local result=
+    for word in $@; do
+        result="$word $result"
+    done
+    echo "$result" 
+}
+
+get_dw_opcode(){
+    local result=
+    local count=0
+    for word in $@; do
+        if [ $count -eq $byte_nums ]; then
+            break;
+        fi
+        result="$result $word"
+        count=$[$count+1]
+    done
+    echo "$result"
+}
+
+delete_blank(){
+    local result=
+    for word in $@; do
+        result="$result$word"
+    done
+    echo "$result"
+}
+
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+opcode_oneline=$(objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o "\s+([a-f0-9][a-f0-9] )+\s*" | xargs)
+opcode_be_dw=$(get_dw_opcode "$opcode_oneline")
+opcode_le_dw=$(reverse_word_order "$opcode_be_dw")
+opcode_unsignedlonglong=$(delete_blank "$opcode_le_dw")
+echo $opcode_unsignedlonglong > $4
+
+
+

--- a/script/get_x86_func_inst.sh
+++ b/script/get_x86_func_inst.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -u
-set -e
-set -x
+#set -u
+#set -e
+#set -x
 #Usage:   ./get_x86_func_inst.sh proc_name func_name byte_nums file_name
 #Example: ./get_x86_func_inst.sh ./test/acc-read-func helper 8 func_helper.tmp
 byte_nums=$3


### PR DESCRIPTION
 * mv get-static-funcinfo to lib
 * mv text process function to arch related shell code
 * read-func.cpp read funcinfo from tempfile and hasn't require has-CET check
 * add ,PHONEY:%.gen target  in makefile static mode acc target
 * avoid to add unportable code in assembly.cpp or test uint.