### PR TITLE
fix: call-mid-func failed when enable Asan

### DIFF
--- a/cfi/call-mid-func.cpp
+++ b/cfi/call-mid-func.cpp
@@ -7,7 +7,7 @@
  * To cope with this effect, an external function is called (gavr_decr()).
  */
 
-void * FORCE_NOINLINE helper() {
+void * FORCE_NOINLINE __attribute__((noreturn)) helper() {
   /* On Apple M1 Darwin 20.6.0 clang 12.0.5:
    * Load the address of a label by adr failed.
    * Using adrp+add is affected by compiler optimization and failed as well.


### PR DESCRIPTION
     *Asan will poison and unpoison func, the previous code exit directtly,
      when Asan try to unpoison func, it failed.So I use attr noreturn to avoid
      Asan unpoisoning helper