### PR TITLE
feat: add riscv support for read-func-inst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,8 @@ extra_objects := $(base)/lib/common/global_var.o $(base)/lib/common/signal.o $(b
 func-opcode-gen := ./script/get_x86_func_inst.sh
 ifeq ($(ARCH), aarch64)
   func-opcode-gen := ./script/get_aarch64_func_inst.sh
+else ifeq ($(ARCH), riscv64)
+  func-opcode-gen := ./script/get_riscv64_func_inst.sh
 endif
 
 # compile targets

--- a/script/get_riscv64_func_inst.sh
+++ b/script/get_riscv64_func_inst.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -u
-set -e
-set -x
+#set -u
+#set -e
+#set -x
 #Usage:   ./get_riscv_func_inst.sh proc_name func_name byte_nums file_name
 #Example: ./get_riscv_func_inst.sh ./test/acc-read-func helper 8 func_helper.tmp
 byte_nums=$3

--- a/script/get_riscv64_func_inst.sh
+++ b/script/get_riscv64_func_inst.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -u
+set -e
+set -x
+#Usage:   ./get_riscv_func_inst.sh proc_name func_name byte_nums file_name
+#Example: ./get_riscv_func_inst.sh ./test/acc-read-func helper 8 func_helper.tmp
+byte_nums=$3
+
+reverse_word_order(){
+    local result=
+    for word in $@; do
+        result="$word $result"
+    done
+    echo "$result" 
+}
+
+reverse_str_order(){
+    local result=
+    for word in $@; do
+        local strlen=${#word}
+	local tmp=
+	    for (( i=$strlen-2; i >=0; i=$i-2)); do
+	        tmp=$tmp${word:$i:2}
+	    done
+            result="$result $tmp"
+    done
+    echo "$result"
+
+}
+
+get_dw_opcode(){
+    local result=
+    local count=0
+    for word in $@; do
+        if [ $count -eq $byte_nums ]; then
+            break;
+        fi
+        result="$result $word"
+        count=$[$count+1]
+    done
+    echo "$result"
+}
+
+delete_blank(){
+    local result=
+    for word in $@; do
+        result="$result$word"
+    done
+    echo "$result"
+}
+
+func_addr="$( objdump -C -t "$1" | grep "$2" | grep -o -E "^[a-f0-9]+" )"
+func_addr="0x""${func_addr}"
+opcode_oneline=$(objdump -C -d --start-address="${func_addr}" "$1" | sed -n '/.*<helper(.*)>:/,/^$/p' | sed '1d' | grep -E -o ":\s+[a-f0-9]+\s*" | grep -E -o "[a-f0-9]+\s*" | xargs)
+# revert twice to revert group(inner ordered)
+opcode_revstr_oneline=$(reverse_str_order "$opcode_oneline")
+opcode_blank_revstr_oneline=$(echo $opcode_revstr_oneline| sed 's/\([a-f0-9][a-f0-9]\)/\1 /g')
+opcode_be_dw=$(get_dw_opcode "$opcode_blank_revstr_oneline")
+opcode_le_dw=$(reverse_word_order "$opcode_be_dw")
+opcode_unsignedlonglong=$(delete_blank "$opcode_le_dw")
+echo $opcode_unsignedlonglong > $4


### PR DESCRIPTION
      *riscv objdump has the little endian number output which is
       different from x86/arm objdump's bigendian output
      *Flip twice to maintain positive sequence within the inst byte group
       and reverse sequence between the inst byte groups