### PR TITLE
fix: When Asan enabled in Aarch64, the ra-offset deviation occurs.

### DIFF
--- a/cfi/return-to-wrong-call-site-within-static-analysis.cpp
+++ b/cfi/return-to-wrong-call-site-within-static-analysis.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include "include/global_var.hpp"
+#include <string>
 
 volatile arch_int_t offset;
 
@@ -20,7 +21,12 @@ void FORCE_NOINLINE helper(void *label) {
 int main(int argc, char* argv[])
 {
   // get the offset of RA on stack
-  offset = 4 * (argv[1][0] - '0');
+  std::string cmd_var_offset = argv[1];
+  std::string cmd_range_offset = argv[2];
+  arch_int_t var_offset = stoll(cmd_var_offset);
+  arch_int_t range_offset = stoll(cmd_range_offset);
+
+  offset = 4*(range_offset + var_offset);
   void *ret_label = &&RET_POS;
   gvar_init(0);
   if(offset == -1) goto *ret_label;  // impossible to run here

--- a/configure.json
+++ b/configure.json
@@ -766,7 +766,7 @@
                      "1": [ ["mss-overflow-write-index-stack", "mss-underflow-write-index-stack",
                              "mss-overflow-write-ptr-stack",   "mss-underflow-write-ptr-stack"] ]
                    },
-        "arguments": { "0": ["-vstack-offset-v-p-g1"],
+        "arguments": { "0": ["-vstack-offset-v-p-g1", "-roffset"],
                        "1": ["-roffset"]
                      },
         "offset": [0, 8, 1],
@@ -774,8 +774,9 @@
                      "1": ["stack-offset-v-p-g1"]
                    },
         "retry-results": { "1": "failed to change RA on stack at all, normal return.",
-                           "267": "RA is partially written leading to a segment error due to wrong RA."
-                         }
+                           "267": "RA is partially written leading to a segment error due to wrong RA.",
+                           "251": "When Arm Asan Enabled, the clang compiler pushes two more registers(one for shadow memory, another for alignment)"
+                        }
     },
     "cfi-return-to-wrong-call-site": {
         "require": { "0": [ [ "cfi-return-to-wrong-call-site-within-static-analysis" ] ] },


### PR DESCRIPTION
    *helper() in cfi-return-to-wrong-call-site-within-static-analysis
     has store inst which is not exited in acc-get-ra-offset's helper func.
     So clang would push two registers to reserve shadow memory base(check the security of store inst).
     And one register is for Asan, another is for 16 bytes sp alignment.
    *cfi-return-to-wrong-call-site is still affected, try to fix it in next commit.