### PR TITLE
fix: suppress M1 clang12.0 opt which leads to false prediciton

### DIFF
--- a/lib/common/mss.cpp
+++ b/lib/common/mss.cpp
@@ -27,7 +27,7 @@ void update_by_index(charBuffer& cb, long long offset, long long size, int step,
     cb.data[i] = c;
 }
 
-void update_by_pointer(char *buf, long long offset, long long size, int step, char c) {
+void __attribute__((noinline)) update_by_pointer(char *buf, long long offset, long long size, int step, char c) {
   buf += offset;
   for(long long i=0; i != size; i += step, buf += step)
     *buf = c;

--- a/lib/include/mss.hpp
+++ b/lib/include/mss.hpp
@@ -32,7 +32,7 @@ public:
 };
 
 extern void update_by_index(charBuffer& cb, long long offset, long long size, int step, char c);
-extern void update_by_pointer(char *buf, long long offset, long long size, int step, char c);
+extern void __attribute__((noinline)) update_by_pointer(char *buf, long long offset, long long size, int step, char c);
 extern int read_by_index(const charBuffer& cb, long long offset, long long size, int step, char c);
 
 template<typename T>
@@ -43,7 +43,7 @@ int read_by_pointer(const T *buf, long long offset, long long size, int step, T 
   return 0;
 }
 
-template<typename T>
+template<typename T> __attribute__((noinline))
 int check(const T *buf, int size, int step, T c) {
   for(int i=0; i!= size; i += step)
     if(buf[i] != c) return 1;


### PR DESCRIPTION
     *mts-write-before-reclaim-heap affected
     *mts-write-before-reclaim-stack affected