### PR TITLE
fix: suppress M1 clang12.0 opt which leads to false prediciton

### DIFF
--- a/lib/common/mss.cpp
+++ b/lib/common/mss.cpp
@@ -27,7 +27,7 @@ void update_by_index(charBuffer& cb, long long offset, long long size, int step,
     cb.data[i] = c;
 }
 
-void update_by_pointer(char *buf, long long offset, long long size, int step, char c) {
+void FORCE_NOINLINE update_by_pointer(char *buf, long long offset, long long size, int step, char c) {
   buf += offset;
   for(long long i=0; i != size; i += step, buf += step)
     *buf = c;

--- a/lib/include/mss.hpp
+++ b/lib/include/mss.hpp
@@ -1,6 +1,7 @@
 #ifndef BOF_HPP_INCLUDED
 #define BOF_HPP_INCLUDED
 
+#include "include/gcc_builtin.hpp"
 #define CB_BUF_LEN 8
 
 class charBuffer
@@ -32,7 +33,7 @@ public:
 };
 
 extern void update_by_index(charBuffer& cb, long long offset, long long size, int step, char c);
-extern void update_by_pointer(char *buf, long long offset, long long size, int step, char c);
+extern void FORCE_NOINLINE update_by_pointer(char *buf, long long offset, long long size, int step, char c);
 extern int read_by_index(const charBuffer& cb, long long offset, long long size, int step, char c);
 
 template<typename T>
@@ -43,7 +44,7 @@ int read_by_pointer(const T *buf, long long offset, long long size, int step, T 
   return 0;
 }
 
-template<typename T>
+template<typename T> FORCE_NOINLINE
 int check(const T *buf, int size, int step, T c) {
   for(int i=0; i!= size; i += step)
     if(buf[i] != c) return 1;

--- a/mts/access-after-free-alias-stack.cpp
+++ b/mts/access-after-free-alias-stack.cpp
@@ -1,4 +1,3 @@
-#include "include/gcc_builtin.hpp"
 #include "include/mss.hpp"
 
 charBuffer *gbuffer;

--- a/mts/reallocate-stack.cpp
+++ b/mts/reallocate-stack.cpp
@@ -1,4 +1,3 @@
-#include "include/gcc_builtin.hpp"
 #include "include/mss.hpp"
 #include <cstdint>
 

--- a/mts/write-before-reclaim-stack.cpp
+++ b/mts/write-before-reclaim-stack.cpp
@@ -1,4 +1,3 @@
-#include "include/gcc_builtin.hpp"
 #include "include/mss.hpp"
 
 charBuffer *gbuffer;


### PR DESCRIPTION
      *mts-write-before-reclaim-heap affected
      *mts-write-before-reclaim-stack affected
      *mts-access-after-reclaim-heap affected
      *mts-access-after-reclaim-stack affected