### PR TITLE
feat: add large unaligned length array member overflow/underflow test

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -129,6 +129,56 @@
         "require": { "0": [["mss-check-intra-obj-rodata-redzone"]] },
         "expect-results": {"290": "cheri capabilities enabled."}
     },
+
+    "mss-overflow-large-read-ptr-stack": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["0", "0"] },
+        "require": { "0": [["mss-check-intra-obj-stack-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-overflow-large-read-ptr-heap": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["1", "0"] },
+        "require": { "0": [["mss-check-intra-obj-heap-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-overflow-large-read-ptr-data": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["2", "0"] },
+        "require": { "0": [["mss-check-intra-obj-data-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-overflow-large-read-ptr-rodata": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["3", "0"] },
+        "require": { "0": [["mss-check-intra-obj-rodata-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-read-ptr-stack": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["0", "1"] },
+        "require": { "0": [["mss-check-intra-obj-stack-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-read-ptr-heap": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["1", "1"] },
+        "require": { "0": [["mss-check-intra-obj-heap-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-read-ptr-data": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["2", "1"] },
+        "require": { "0": [["mss-check-intra-obj-data-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-read-ptr-rodata": {
+        "program": "mss-read-large-member-inter-object",
+        "arguments": { "0": ["3", "1"] },
+        "require": { "0": [["mss-check-intra-obj-rodata-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+
     "mss-overflow-write-index-stack": {
         "program": "mss-write-by-index",
         "arguments": { "0": ["0", "0"] },
@@ -206,6 +256,42 @@
         "arguments": { "0": ["2", "1"] },
         "require": { "0": [["mss-check-intra-obj-data-redzone"]] },
         "reference": { "cwe": ["119"] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-overflow-large-write-ptr-stack": {
+        "program": "mss-write-large-member-inter-object",
+        "arguments": { "0": ["0", "0"] },
+        "require": { "0": [["mss-check-intra-obj-stack-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-overflow-large-write-ptr-heap": {
+        "program": "mss-write-large-member-inter-object",
+        "arguments": { "0": ["1", "0"] },
+        "require": { "0": [["mss-check-intra-obj-heap-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-overflow-large-write-ptr-data": {
+        "program": "mss-write-large-member-inter-object",
+        "arguments": { "0": ["2", "0"] },
+        "require": { "0": [["mss-check-intra-obj-data-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-write-ptr-stack": {
+        "program": "mss-write-large-member-inter-object",
+        "arguments": { "0": ["0", "1"] },
+        "require": { "0": [["mss-check-intra-obj-stack-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-write-ptr-heap": {
+        "program": "mss-write-large-member-inter-object",
+        "arguments": { "0": ["1", "1"] },
+        "require": { "0": [["mss-check-intra-obj-heap-redzone"]] },
+        "expect-results": {"290": "cheri capabilities enabled."}
+    },
+    "mss-underflow-large-write-ptr-data": {
+        "program": "mss-write-large-member-inter-object",
+        "arguments": { "0": ["2", "1"] },
+        "require": { "0": [["mss-check-intra-obj-data-redzone"]] },
         "expect-results": {"290": "cheri capabilities enabled."}
     },
     "mss-read-cross-object-index-stack": {

--- a/lib/common/mss.cpp
+++ b/lib/common/mss.cpp
@@ -22,6 +22,28 @@ void charBuffer::updateBuffer(const char uf, const char d, const char of){
   overflow[CB_BUF_LEN-1]  = 0;
 }
 
+LargeMemberBuffer::LargeMemberBuffer(const char uf, const char d, const char of){
+  for(unsigned int i=0; i!=LARGE_UNALIGNED_BUF_LEN-1; i++) {
+    underflow[i] = uf;
+    data[i] = d;
+    overflow[i] = of;
+  }
+  underflow[LARGE_UNALIGNED_BUF_LEN-1] = 0;
+  data[LARGE_UNALIGNED_BUF_LEN-1]      = 0;
+  overflow[LARGE_UNALIGNED_BUF_LEN-1]  = 0;
+}
+
+void LargeMemberBuffer::updateBuffer(const char uf, const char d, const char of){
+  for(unsigned int i=0; i!=LARGE_UNALIGNED_BUF_LEN-1; i++) {
+    underflow[i] = uf;
+    data[i] = d;
+    overflow[i] = of;
+  }
+  underflow[LARGE_UNALIGNED_BUF_LEN-1] = 0;
+  data[LARGE_UNALIGNED_BUF_LEN-1]      = 0;
+  overflow[LARGE_UNALIGNED_BUF_LEN-1]  = 0;
+}
+
 void update_by_index(charBuffer& cb, long long offset, long long size, int step, char c) {
   for(long long i=offset; i != size+offset; i += step)
     cb.data[i] = c;

--- a/lib/include/mss.hpp
+++ b/lib/include/mss.hpp
@@ -3,6 +3,7 @@
 
 #include "include/gcc_builtin.hpp"
 #define CB_BUF_LEN 8
+#define LARGE_UNALIGNED_BUF_LEN 0xfff0
 
 class charBuffer
 {
@@ -13,6 +14,18 @@ public:
 
   charBuffer() = default;
   charBuffer(const char uf, const char d, const char of);
+  void updateBuffer(const char uf, const char d, const char of);
+};
+
+class LargeMemberBuffer
+{
+public:
+  char underflow[LARGE_UNALIGNED_BUF_LEN];
+  char data[LARGE_UNALIGNED_BUF_LEN];
+  char overflow[LARGE_UNALIGNED_BUF_LEN];
+
+  LargeMemberBuffer() = default;
+  LargeMemberBuffer(const char uf, const char d, const char of);
   void updateBuffer(const char uf, const char d, const char of);
 };
 

--- a/mss/read-large-member-inter-object.cpp
+++ b/mss/read-large-member-inter-object.cpp
@@ -1,0 +1,43 @@
+#include "include/mss.hpp"
+
+const LargeMemberBuffer buffer_rodata('u','d','o');
+// buffer in data
+LargeMemberBuffer buffer_data('u','d','o');
+
+int main(int argc, char* argv[])
+{
+  // buffer in local stack
+  LargeMemberBuffer buffer_stack('u','d','o');
+
+  // buffer allocated in heap
+  LargeMemberBuffer *buffer_heap = new LargeMemberBuffer('u','d','o');
+
+  int store_type = argv[1][0] - '0';
+  int flow_type  = argv[2][0] - '0';
+
+  int rv;
+
+  switch(store_type*2+flow_type) {
+  case 0: // stack overflow
+    rv = read_by_pointer(buffer_stack.data,   LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN-1, 1, 'o'); break;
+  case 1: // stack underflow
+    rv = read_by_pointer(buffer_stack.data,  -LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'u'); break;
+  case 2: // heap overflow
+    rv = read_by_pointer(buffer_heap->data,   LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'o'); break;
+  case 3: // heap underflow
+    rv = read_by_pointer(buffer_heap->data,  -LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'u'); break;
+  case 4: // data overflow
+    rv = read_by_pointer(buffer_data.data,    LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'o'); break;
+  case 5: // data underflow
+    rv = read_by_pointer(buffer_data.data,   -LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'u'); break;
+  case 6: // rodata underflow
+    rv = read_by_pointer(buffer_rodata.data,  LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'o'); break;
+  case 7: // rodata underflow
+    rv = read_by_pointer(buffer_rodata.data, -LARGE_UNALIGNED_BUF_LEN, LARGE_UNALIGNED_BUF_LEN, 1, 'u'); break;
+  default:
+    rv = -1;
+  }
+
+  delete buffer_heap;
+  return rv;
+}

--- a/mss/write-large-member-inter-object.cpp
+++ b/mss/write-large-member-inter-object.cpp
@@ -1,0 +1,51 @@
+#include "include/mss.hpp"
+
+const LargeMemberBuffer buffer_rodata('u','d','o');
+// buffer in data
+LargeMemberBuffer buffer_data('u','d','o');
+
+int main(int argc, char* argv[])
+{
+  // buffer in local stack
+  LargeMemberBuffer buffer_stack('u','d','o');
+
+  // buffer allocated in heap
+  LargeMemberBuffer *buffer_heap = new charBuffer('u','d','o');
+
+  int store_type = argv[1][0] - '0';
+  int flow_type  = argv[2][0] - '0';
+
+  int rv;
+
+  switch(store_type*2+flow_type) {
+  case 0: // stack overflow
+    update_by_pointer(buffer_stack.data, LARGE_UNALIGNED_BUF_LEN, 1,  1, 'c');
+    rv = check(buffer_stack.overflow,      1,  1, 'c');
+    break;
+  case 1: // stack underflow
+    update_by_pointer(buffer_stack.data, 0, -1, -1, 'c');
+    rv = check(buffer_stack.underflow,   LARGE_UNALIGNED_BUF_LEN-1,  1, 'c');
+    break;
+  case 2: // heap overflow
+    update_by_pointer(buffer_heap->data, LARGE_UNALIGNED_BUF_LEN, 1,  1, 'c');
+    rv = check(buffer_heap->overflow,      1,  1, 'c');
+    break;
+  case 3: // heap underflow
+    update_by_pointer(buffer_heap->data, 0, -1, -1, 'c');
+    rv = check(buffer_heap->underflow,   LARGE_UNALIGNED_BUF_LEN-1,  1, 'c');
+    break;
+  case 4: // data overflow
+    update_by_pointer(buffer_data.data,  LARGE_UNALIGNED_BUF_LEN, 1,  1, 'c');
+    rv = check(buffer_data.overflow,       1,  1, 'c');
+    break;
+  case 5: // data underflow
+    update_by_pointer(buffer_data.data,  0, -1, -1, 'c');
+    rv = check(buffer_data.underflow,    LARGE_UNALIGNED_BUF_LEN-1,  1, 'c');
+    break;
+  default:
+    rv = -1;
+  }
+
+  delete buffer_heap;
+  return rv;
+}


### PR DESCRIPTION
   * extended pointer in cheri/morello has extra field which contains upper bound and lower bound. Specific Hardwares will use this field to check cross-border access. When the length of array is too long to express the bound accurately, it will expose the vulnerability