### PR TITLE
Feat: add Windows Structure Exceptions Suppot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,13 @@ sec-tests := $(mss-tests) $(mts-tests) $(acc-tests) $(cpi-tests) $(cfi-tests)
 sec-tests-dump = $(addsuffix .dump, $(sec-tests))
 sec-tests-prep := $(mss-cpps-prep) $(mts-cpps-prep) $(acc-cpps-prep) $(cpi-cpps-prep) $(cfi-cpps-prep)
 
-headers := $(wildcard lib/include/*.hpp) $(wildcard lib/$(ARCH)/*.hpp)
-extra_objects := lib/common/global_var.o lib/common/signal.o lib/common/temp_file.o $(addprefix lib/$(ARCH)/, assembly.o)
+ifeq ($(OSType),Windows_NT)
+  extra_objects := lib/common/global_var.o lib/common/visualc++/signal.o lib/common/temp_file.o $(addprefix lib/$(ARCH)/, assembly.o)
+  headers := $(wildcard lib/include/*.hpp) $(wildcard lib/$(ARCH)/*.hpp) $(wildcard lib/include/visualc++/*.hpp)
+else
+  extra_objects := lib/common/global_var.o lib/common/posix/signal.o lib/common/temp_file.o $(addprefix lib/$(ARCH)/, assembly.o)
+  headers := $(wildcard lib/include/*.hpp) $(wildcard lib/$(ARCH)/*.hpp) $(wildcard lib/include/posix/*.hpp)
+endif
 
 func-opcode-gen := ./script/get_x86_func_inst.sh
 ifeq ($(ARCH), aarch64)

--- a/acc/check-ASLR.cpp
+++ b/acc/check-ASLR.cpp
@@ -1,9 +1,14 @@
 #include <string>
 #include <cstdlib>
 #include <cstdint>
-#include "include/gcc_builtin.hpp"
 #include <fstream>
 //#include <iostream>
+
+#if defined(__GNUC__)
+  #include "include/posix/gcc_builtin.hpp"
+#else
+  #include "include/visualc++/msvc_builtin.hpp"
+#endif
 
 int FORCE_NOINLINE helper(uintptr_t p0, uintptr_t p1) {
   // if debug code is really needed for future use, keep it simple and commented out

--- a/cfi/call-wrong-func-vtable-released.cpp
+++ b/cfi/call-wrong-func-vtable-released.cpp
@@ -15,8 +15,13 @@ int main()
   Fake *fake = new Fake();
   delete fake;
   write_vtable_pointer(orig, *((pvtable_t *)fake));
-  begin_catch_exception((void *)NULL, (int)SEGV_MAPERR, 17);
-  begin_catch_exception((void *)NULL, (int)SEGV_ACCERR, 18);
+  #if defined(_MSC_VER)
+    begin_catch_exception((void *)NULL, (ULONG*)NULL, (ULONG)17, (ULONG)EXCEPTION_IN_PAGE_ERROR);
+    begin_catch_exception((void *)NULL, (ULONG*)NULL, (ULONG)18, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+  #else
+    begin_catch_exception((void *)NULL, (int)SEGV_MAPERR, 17);
+    begin_catch_exception((void *)NULL, (int)SEGV_ACCERR, 18);
+  #endif
   orig->virtual_func();
   end_catch_exception();
   end_catch_exception();

--- a/cfi/call-wrong-type-arg-dp2fp-func-data.cpp
+++ b/cfi/call-wrong-type-arg-dp2fp-func-data.cpp
@@ -16,9 +16,15 @@ int main()
 {
   int rv = m[0];
   printf("dummy print: m = %p\n", m);
+  #if defined(_MSC_VER)
+  begin_catch_exception(m, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+  #else
   begin_catch_exception(m, SEGV_ACCERR);
   begin_catch_exception(m+4, 0, 0, SIGILL);
   begin_catch_exception(m+4, 0, 0, SIGFPE);
+  #endif
   rv = helper((func_type)(&m));
   end_catch_exception();
   end_catch_exception();

--- a/cfi/call-wrong-type-arg-dp2fp-func-heap.cpp
+++ b/cfi/call-wrong-type-arg-dp2fp-func-heap.cpp
@@ -17,9 +17,15 @@ int main()
   assign_fake_machine_code(m);
   int rv = m[0];
   printf("dummy print: m = %p\n", m);
+  #if defined(_MSC_VER)
+  begin_catch_exception(m, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+  #else
   begin_catch_exception(m, SEGV_ACCERR);
   begin_catch_exception(m+4, 0, 0, SIGILL);
   begin_catch_exception(m+4, 0, 0, SIGFPE);
+  #endif
   rv = helper((func_type)(m));
   end_catch_exception();
   end_catch_exception();

--- a/cfi/call-wrong-type-arg-dp2fp-func-rodata.cpp
+++ b/cfi/call-wrong-type-arg-dp2fp-func-rodata.cpp
@@ -14,9 +14,15 @@ int FORCE_NOINLINE helper(func_type fp) {
 int main()
 {
   int rv = m[0];
+  #if defined(_MSC_VER)
+  begin_catch_exception(m, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+  #else
   begin_catch_exception(m, SEGV_ACCERR);
   begin_catch_exception(m+4, 0, 0, SIGILL);
   begin_catch_exception(m+4, 0, 0, SIGFPE);
+  #endif
   rv = helper((func_type)(&m));
   end_catch_exception();
   end_catch_exception();

--- a/cfi/call-wrong-type-arg-dp2fp-func-stack.cpp
+++ b/cfi/call-wrong-type-arg-dp2fp-func-stack.cpp
@@ -16,9 +16,15 @@ int main()
   unsigned char m[] = FUNC_MACHINE_CODE;
   int rv = m[0];
   printf("dummy print: m = %p\n", m);
+  #if defined(_MSC_VER)
+  begin_catch_exception(m, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+  begin_catch_exception(m+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+  #else
   begin_catch_exception(m, SEGV_ACCERR);
   begin_catch_exception(m+4, 0, 0, SIGILL);
   begin_catch_exception(m+4, 0, 0, SIGFPE);
+  #endif
   rv = helper((func_type)(&m));
   end_catch_exception();
   end_catch_exception();

--- a/cfi/code-injection.cpp
+++ b/cfi/code-injection.cpp
@@ -79,13 +79,20 @@ int main(int argc, char* argv[])
     break;
   }
 
+#if defined(_MSC_VER)
+  begin_catch_exception(addr, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+
+  begin_catch_exception(addr+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+  begin_catch_exception(addr+4, (ULONG*)NULL, 0, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+#else
   begin_catch_exception(addr, SEGV_ACCERR);
-#ifdef CSB_ARMV8_64
-  // bus error on Apple M1
-  begin_catch_exception(addr, BUS_ADRALN, RT_CODE_ACCERR, SIGBUS);
-#endif
+  #ifdef CSB_ARMV8_64
+    // bus error on Apple M1
+    begin_catch_exception(addr, BUS_ADRALN, RT_CODE_ACCERR, SIGBUS);
+  #endif
   begin_catch_exception(addr+4, 0, 0, SIGILL);
   begin_catch_exception(addr+4, 0, 0, SIGFPE);
+#endif
   switch(argv[1][0] - '0') {
   case 0: return_helper(p); break;
   case 1: call_helper(f); break;

--- a/cfi/return-without-call.cpp
+++ b/cfi/return-without-call.cpp
@@ -19,7 +19,11 @@ int main(int argc, char* argv[])
 {
   gvar_init(argv[1][0] - '0');
   arch_int_t fsize = (argv[2][0] - '0') * 4 / sizeof(arch_int_t);
+  #if defined(_MSC_VER)
+  begin_catch_exception((void *)NULL, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_DATATYPE_MISALIGNMENT);
+  #else
   begin_catch_exception((void *)NULL, BUS_ADRALN, RT_CODE_ACCERR, SIGBUS);
+  #endif
   helper(fsize);
   end_catch_exception();
   return gvar();

--- a/cpi/modify-GOT.cpp
+++ b/cpi/modify-GOT.cpp
@@ -23,7 +23,11 @@ int main(int argc, char* argv[])
   rand();
   COMPILER_BARRIER;
 
-  begin_catch_exception(got, SEGV_ACCERR);
+  #if defined(_MSC_VER)
+    begin_catch_exception(got, (ULONG*)NULL, RT_CODE_ACCERR, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+  #else
+    begin_catch_exception(got, SEGV_ACCERR);
+  #endif
   replace_got_func((void **)helper, got);
   end_catch_exception();
 

--- a/lib/common/posix/signal.cpp
+++ b/lib/common/posix/signal.cpp
@@ -1,5 +1,7 @@
-#include "include/signal.hpp"
-#include "include/gcc_builtin.hpp"
+#if defined(__GNUC__)
+  #include "include/posix/signal.hpp"
+  #include "include/posix/gcc_builtin.hpp"
+#endif
 #include <cstdlib>
 #include <cstdio>
 #include <vector>

--- a/lib/common/visualc++/signal.cpp
+++ b/lib/common/visualc++/signal.cpp
@@ -1,0 +1,115 @@
+#if defined(_MSC_VER)
+  #include "include/visualc++/signal.hpp"
+  #include "include/visualc++/msvc_builtin.hpp"
+#endif
+#include <cstdlib>
+#include <cstdio>
+#include <vector>
+
+// information recorded for exception checking
+struct exception_record_t{
+  enum {PTR,PTRPTR} tok;
+  union {
+    // faulty memory location: SIGILL, SIGFPE, SIGSEGV, SIGBUS, and SIGTRAP
+    const PVOID si_ExceptionAddress;
+    const PVOID *si_IndExceptionAddress;
+  };
+  DWORD si_ExceptionCode;
+  ULONG* si_ExceptionInformation;
+  int rv_code;
+  exception_record_t() = default;
+  exception_record_t (const PVOID si_ExceptionAddress, DWORD si_ExceptionCode, ULONG* si_ExceptionInformation, int rv_code):
+  tok(PTR), si_ExceptionAddress(si_ExceptionAddress), si_ExceptionCode(si_ExceptionCode), si_ExceptionInformation(si_ExceptionInformation),
+  rv_code(rv_code){};
+  exception_record_t (const PVOID *si_IndExceptionAddress, DWORD si_ExceptionCode, ULONG* si_ExceptionInformation, int rv_code):
+  tok(PTRPTR), si_ExceptionAddress(si_ExceptionAddress), si_ExceptionCode(si_ExceptionCode), si_ExceptionInformation(si_ExceptionInformation),
+  rv_code(rv_code){};
+  exception_record_t operator=(const exception_record_t & e){
+    if(e.tok == PTR)
+      return exception_record_t(e.si_ExceptionAddress,e.si_ExceptionCode,e.si_ExceptionInformation,e.rv_code);
+    else
+      return exception_record_t(e.si_IndExceptionAddress,e.si_ExceptionCode,e.si_ExceptionInformation,e.rv_code);
+  }
+};
+
+static std::vector<exception_record_t> sigact_stack(16);
+PVOID installed_handler = NULL;
+static int svp = -1;
+
+LONG WINAPI TopLevelUnhandledExceptionFilter(PEXCEPTION_POINTERS pExceptioninfo){
+    perror("begin_catch_nx_exception() fails to catch EXCEPTIONS!");
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+bool checkExceptInformation(ULONG* record_exceptionInfo, ULONG_PTR* exceptionInfo){
+
+  for(int i = 0; i != EXCEPTION_MAXIMUM_PARAMETERS; i++){
+    if(record_exceptionInfo[i] != exceptionInfo[i])
+      return false;
+  }
+  return true;
+
+}
+
+LONG WINAPI ExceptionHandler(struct _EXCEPTION_POINTERS* pExceptionInfo){
+  // check the exception cause
+  for(int i=svp; i>=0; i--) {
+    if((sigact_stack[i].si_ExceptionCode == pExceptionInfo->ExceptionRecord->ExceptionCode) &&
+       (sigact_stack[i].si_ExceptionInformation == NULL ||
+       checkExceptInformation(sigact_stack[i].si_ExceptionInformation,(pExceptionInfo->ExceptionRecord->ExceptionInformation))) &&
+      (sigact_stack[i].si_ExceptionAddress == NULL ||
+      sigact_stack[i].si_ExceptionAddress == pExceptionInfo->ExceptionRecord->ExceptionAddress))
+      exit(sigact_stack[i].rv_code);
+  }
+
+  fprintf(stderr, "ExceptionHandler(): mismatched signal with ExceptionCode = %d, ExceptionAddress = 0x%p\n",
+   pExceptionInfo->ExceptionRecord->ExceptionCode, pExceptionInfo->ExceptionRecord->ExceptionAddress);
+
+  fprintf(stderr,"ExceptionInformation is:");
+  for(int i = 0; i != EXCEPTION_MAXIMUM_PARAMETERS; i++){
+    fprintf(stderr," %d",pExceptionInfo->ExceptionRecord->ExceptionInformation[i]);
+  }
+  //if(sinfo->si_addr != NULL) fprintf(stderr, "bad data = 0x%lx\n", *(unsigned int *)sinfo->si_addr);
+  //for(int i=svp; i>=0; i--) {
+  //  fprintf(stderr, "registered sigact: si_signo = %d, si_code = %d and fault-addr = 0x%p\n", sigact_stack[i].si_signo, sigact_stack[i].si_code, sigact_stack[i].daddr);
+  //}
+  exit(RT_CODE_MISMATCH);
+  return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void begin_catch_exception(const PVOID expected_faulty_addr, ULONG* si_code,
+                      int rv_code, DWORD si_signo){
+    if(svp < 0){
+        if(SetUnhandledExceptionFilter(TopLevelUnhandledExceptionFilter) != NULL){
+            perror("SetUnhandledExceptionFilter() already has set TopLevelUnhandledExceptionFilter!");
+        }
+        installed_handler = AddVectoredExceptionHandler(0,ExceptionHandler);
+    }
+    sigact_stack[++svp] = {expected_faulty_addr, si_signo, si_code, rv_code};
+}
+
+void begin_catch_exception(const PVOID* expected_faulty_addr, ULONG* si_code,
+                      int rv_code, DWORD si_signo){
+    if(svp < 0){
+        if(SetUnhandledExceptionFilter(TopLevelUnhandledExceptionFilter) != NULL){
+            perror("SetUnhandledExceptionFilter() already has set TopLevelUnhandledExceptionFilter!");
+        }
+        installed_handler = AddVectoredExceptionHandler(0,ExceptionHandler);
+    }
+    sigact_stack[++svp] = {expected_faulty_addr, si_signo, si_code, rv_code};
+}
+
+void end_catch_exception() {
+  --svp;
+  if(svp < 0) {
+    if(SetUnhandledExceptionFilter(NULL) == NULL){
+      perror("SetUnhandledExceptionFilter() fails to set TopLevelUnhandledExceptionFilter previously!");
+      exit(-1);
+    }
+    if(!RemoveVectoredExceptionHandler(installed_handler)){
+      perror("end_catch_nx_exception() fails to reset Vectored Exception!");
+      exit(-1);
+    }
+  }
+}
+

--- a/lib/include/assembly.hpp
+++ b/lib/include/assembly.hpp
@@ -3,7 +3,11 @@
 #ifndef ASSEMBLY_HPP_INCLUDED
 #define ASSEMBLY_HPP_INCLUDED
 
-#include "include/gcc_builtin.hpp"
+#if defined(__GNUC__) 
+  #include "include/posix/gcc_builtin.hpp"
+#else
+  #include "include/visualc++/msvc_builtin.hpp"
+#endif
 
 // detect ISA
 #if defined(__x86_64) || defined(_MSC_VER)

--- a/lib/include/mss.hpp
+++ b/lib/include/mss.hpp
@@ -1,7 +1,11 @@
 #ifndef BOF_HPP_INCLUDED
 #define BOF_HPP_INCLUDED
 
-#include "include/gcc_builtin.hpp"
+#if defined(__GNUC__)
+  #include "include/posix/gcc_builtin.hpp"
+#else
+  #include "include/visualc++/msvc_builtin.hpp"
+#endif
 #define CB_BUF_LEN 8
 
 class charBuffer

--- a/lib/include/posix/gcc_builtin.hpp
+++ b/lib/include/posix/gcc_builtin.hpp
@@ -1,5 +1,4 @@
-#ifndef GCC_BUILTIN_HPP_INCLUDED
-#define GCC_BUILTIN_HPP_INCLUDED
+#if defined(__GNUC__)
 
 // make a function incline/non-inline
 #define FORCE_INLINE __attribute__((always_inline)) inline

--- a/lib/include/posix/signal.hpp
+++ b/lib/include/posix/signal.hpp
@@ -10,7 +10,6 @@ const int RT_CODE_ACCERR    = 16;      // no permission to access
 // catch exception for non-execution on writable pages
 extern void begin_catch_exception(const void *expected_faulty_addr, int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV);
 extern void begin_catch_exception(const void **expected_faulty_addr, int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV);
-extern void begin_catch_exception();
 extern void   end_catch_exception();
 
 #endif

--- a/lib/include/visualc++/msvc_builtin.hpp
+++ b/lib/include/visualc++/msvc_builtin.hpp
@@ -1,0 +1,14 @@
+#if defined(_MSC_VER)
+
+// make a function incline/non-inline
+#define FORCE_INLINE __forceinline
+#define FORCE_NOINLINE __declspec(noinline)
+
+// a barrier to stop compiler from reorder memory operations
+// For hardware access, use the /volatile:iso compiler option together with the volatile keyword.
+#define COMPILER_BARRIER __faststorefence
+
+// code/data alignment
+#define ALIGN(NByte) __declspec ((aligned (NByte)))
+
+#endif

--- a/lib/include/visualc++/signal.hpp
+++ b/lib/include/visualc++/signal.hpp
@@ -1,0 +1,17 @@
+#ifndef VISUALCPP_BUILTIN_SEH_INCLUDED
+#define VISUALCPP_BUILTIN_SEH_INCLUDED
+
+#include<Windows.h>
+#include<winnt.h>
+#include<Excpt.h>
+
+const int RT_CODE_MISMATCH  = -1;      // ERROR: mismatched signal
+const int RT_CODE_MAPERR    = 15;      // address not accessible
+const int RT_CODE_ACCERR    = 16;      // no permission to access
+
+// catch exception for non-execution on writable pages
+extern void begin_catch_exception(const PVOID expected_faulty_addr, ULONG* si_code = NULL, int rv_code = RT_CODE_ACCERR, DWORD si_signo = EXCEPTION_ACCESS_VIOLATION);
+extern void begin_catch_exception(const PVOID* expected_faulty_addr, ULONG* si_code = NULL, int rv_code = RT_CODE_ACCERR, DWORD si_signo = EXCEPTION_ACCESS_VIOLATION);
+extern void   end_catch_exception();
+
+#endif

--- a/mts/access-after-reclaim-stack.cpp
+++ b/mts/access-after-reclaim-stack.cpp
@@ -1,5 +1,10 @@
-#include "include/gcc_builtin.hpp"
 #include "include/mss.hpp"
+
+#if defined(__GNUC__) 
+  #include "include/posix/gcc_builtin.hpp"
+#else
+  #include "include/visualc++/msvc_builtin.hpp"
+#endif
 
 charBuffer *pb;
 

--- a/mts/write-after-reclaim-stack.cpp
+++ b/mts/write-after-reclaim-stack.cpp
@@ -1,5 +1,10 @@
-#include "include/gcc_builtin.hpp"
 #include "include/mss.hpp"
+
+#if defined(__GNUC__) 
+  #include "include/posix/gcc_builtin.hpp"
+#else
+  #include "include/visualc++/msvc_builtin.hpp"
+#endif
 
 charBuffer *pb;
 


### PR DESCRIPTION
	*apart builtin and signal header files to different dirs
	according to different OS C/C++ Library
	*use VEH(Vector Exception Handing) to register exception
	 handler and add exception nums which is mapping
	 to linux signal(may not accurate,stil need further test)
	*modify corresponding tests which used linux signal mechanism
	*add copy-assgin operator function in struct exception_record_t
	otherwise it will raise MSVC error C2280
	(function "exception_record t::operator=(const exception_record t &)" (declared implicitly) cannot be referenced -- it is a deleted function)
	because MSVC would surpress default copy-assign operator func