### PR TITLE
Feat: add Windows Structure Exceptions Suppot with minimize modification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ sec-tests-dump = $(addsuffix .dump, $(sec-tests))
 sec-tests-prep := $(mss-cpps-prep) $(mts-cpps-prep) $(acc-cpps-prep) $(cpi-cpps-prep) $(cfi-cpps-prep)
 
 headers := $(wildcard lib/include/*.hpp) $(wildcard lib/$(ARCH)/*.hpp) $(wildcard lib/$(CLIBAPI)/*.hpp)
-extra_objects := lib/common/global_var.o lib/common/signal.o lib/common/temp_file.o $(addprefix lib/$(ARCH)/, assembly.o)
+extra_objects := lib/common/global_var.o lib/common/temp_file.o $(addprefix lib/$(ARCH)/, assembly.o) $(addprefix lib/$(CLIBAPI)/, signal.o)
 
 func-opcode-gen := ./script/get_x86_func_inst.sh
 ifeq ($(ARCH), aarch64)

--- a/lib/include/assembly.hpp
+++ b/lib/include/assembly.hpp
@@ -1,4 +1,4 @@
-// assembly helper functions
+// abi sensitive assembly helper functions
 
 #ifndef ASSEMBLY_HPP_INCLUDED
 #define ASSEMBLY_HPP_INCLUDED

--- a/lib/include/builtin.hpp
+++ b/lib/include/builtin.hpp
@@ -10,7 +10,7 @@
     #endif
 
     #if defined(__GNUC__)
-        #include "include/gcc_builtin.hpp"
+        #include "posix/gcc_builtin.hpp"
         #if defined(__clang__)
             #define COMPILER_CLANG
         #else

--- a/lib/include/signal.hpp
+++ b/lib/include/signal.hpp
@@ -22,83 +22,33 @@
         #define SEGV_ACCERR 2
         #define BUS_ADRALN  3
 
-        inline void begin_catch_exception(const void *expected_faulty_addr, 
-        int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV){
-
-            switch (si_signo)
-            {
-            case SIGSEGV:
-                switch (si_code)
-                {
-                case SEGV_MAPERR:
-                    begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
-                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_IN_PAGE_ERROR);
-                    break;
-                case SEGV_ACCERR:
-                    begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
-                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ACCESS_VIOLATION);
-                    break;
-                default:
-                    break;
-                }
-                break;
-            case SIGILL:
-                begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
-                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
-                break;
-            case SIGFPE:
-                begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
-                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
-                break;
-            case SIGBUS:
-                switch (si_code){
-                    case BUS_ADRALN:
-                        begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
-                        (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_DATATYPE_MISALIGNMENT);
-                    break;
-                }
-            default:
-                break;
+        inline ULONG msvc_code_conv(const int si_code, const int si_signo) {
+          switch (si_signo) {
+          case SIGSEGV:
+            switch (si_code) {
+            case SEGV_MAPERR: return EXCEPTION_IN_PAGE_ERROR;
+            case SEGV_ACCERR: return EXCEPTION_ACCESS_VIOLATION;
+            default:          break;
             }
+          case SIGILL: return EXCEPTION_ILLEGAL_INSTRUCTION;
+          case SIGFPE: return EXCEPTION_FLT_INVALID_OPERATION;
+          case SIGBUS: return EXCEPTION_DATATYPE_MISALIGNMENT;
+          default: break;
+          }
 
+          return 0; // should not run here?
         }
+
+        inline void begin_catch_exception(const void *expected_faulty_addr, 
+                                          int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV) {
+          begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
+                                     (ULONG*)NULL, rv_code, msvc_code_conv(si_code, si_signo));
+        }
+
         inline void begin_catch_exception(const void **expected_faulty_addr,
-        int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV){
-            switch (si_signo)
-            {
-            case SIGSEGV:
-                switch (si_code)
-                {
-                case SEGV_MAPERR:
-                    begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
-                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_IN_PAGE_ERROR);
-                    break;
-                case SEGV_ACCERR:
-                    begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
-                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ACCESS_VIOLATION);
-                    break;
-                default:
-                    break;
-                }
-                break;
-            case SIGILL:
-                begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
-                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
-                break;
-            case SIGFPE:
-                begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
-                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
-                break;
-            case SIGBUS:
-                switch (si_code){
-                    case BUS_ADRALN:
-                        begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
-                        (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_DATATYPE_MISALIGNMENT);
-                    break;
-                }
-            default:
-                break;
-            }
+                                          int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV) {
+          begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
+                                     (ULONG*)NULL, rv_code, msvc_code_conv(si_code, si_signo));
         }
 
     #endif

--- a/lib/include/signal.hpp
+++ b/lib/include/signal.hpp
@@ -13,7 +13,7 @@
         /*replace begin_catch_exception() with
         begin_catch_exception_msvc() to smooth the gap between diff
         CAPI*/
-        #include "visualc++/signal.hpp"
+        #include "visualcpp/signal.hpp"
         //define posix sig num for visualc++ porting
         #define SIGBUS 20
         //define posix sig code for visualc++ porting

--- a/lib/include/signal.hpp
+++ b/lib/include/signal.hpp
@@ -1,16 +1,119 @@
-#ifndef GCC_BUILTIN_SIGNAL_INCLUDED
-#define GCC_BUILTIN_SIGNAL_INCLUDED
+// api sensitive signal functions
 
-#include <csignal>
+#ifndef SIGNAL_HPP_INCLUDED
+#define SIGNAL_HPP_INCLUDED
 
-const int RT_CODE_MISMATCH  = -1;      // ERROR: mismatched signal
-const int RT_CODE_MAPERR    = 15;      // address not accessible
-const int RT_CODE_ACCERR    = 16;      // no permission to access
+    #include <csignal>
+    #include <cstdlib>
+    #include <cstdio>
+    #include <vector>
+    #include "include/builtin.hpp"
+    // detect compiler
+    #if defined(_MSC_VER)
+        /*replace begin_catch_exception() with
+        begin_catch_exception_msvc() to smooth the gap between diff
+        CAPI*/
+        #include "visualc++/signal.hpp"
+        //define posix sig num for visualc++ porting
+        #define SIGBUS 20
+        //define posix sig code for visualc++ porting
+        //so the macro value is meanless
+        #define SEGV_MAPERR 1
+        #define SEGV_ACCERR 2
+        #define BUS_ADRALN  3
 
-// catch exception for non-execution on writable pages
-extern void begin_catch_exception(const void *expected_faulty_addr, int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV);
-extern void begin_catch_exception(const void **expected_faulty_addr, int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV);
-extern void begin_catch_exception();
-extern void   end_catch_exception();
+        inline void begin_catch_exception(const void *expected_faulty_addr, 
+        int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV){
+
+            switch (si_signo)
+            {
+            case SIGSEGV:
+                switch (si_code)
+                {
+                case SEGV_MAPERR:
+                    begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
+                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_IN_PAGE_ERROR);
+                    break;
+                case SEGV_ACCERR:
+                    begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
+                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+                    break;
+                default:
+                    break;
+                }
+                break;
+            case SIGILL:
+                begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
+                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+                break;
+            case SIGFPE:
+                begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
+                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+                break;
+            case SIGBUS:
+                switch (si_code){
+                    case BUS_ADRALN:
+                        begin_catch_exception_msvc((PVOID*)expected_faulty_addr, 
+                        (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_DATATYPE_MISALIGNMENT);
+                    break;
+                }
+            default:
+                break;
+            }
+
+        }
+        inline void begin_catch_exception(const void **expected_faulty_addr,
+        int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV){
+            switch (si_signo)
+            {
+            case SIGSEGV:
+                switch (si_code)
+                {
+                case SEGV_MAPERR:
+                    begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
+                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_IN_PAGE_ERROR);
+                    break;
+                case SEGV_ACCERR:
+                    begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
+                    (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ACCESS_VIOLATION);
+                    break;
+                default:
+                    break;
+                }
+                break;
+            case SIGILL:
+                begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
+                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_ILLEGAL_INSTRUCTION);
+                break;
+            case SIGFPE:
+                begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
+                (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_FLT_INVALID_OPERATION);
+                break;
+            case SIGBUS:
+                switch (si_code){
+                    case BUS_ADRALN:
+                        begin_catch_exception_msvc((PVOID**)expected_faulty_addr, 
+                        (ULONG*)NULL, rv_code, (ULONG)EXCEPTION_DATATYPE_MISALIGNMENT);
+                    break;
+                }
+            default:
+                break;
+            }
+        }
+
+    #endif
+
+    #if defined(__GNUC__)
+        /*for posix, just pass it to original begin_catch_exception() func*/
+        #include "posix/signal.hpp"
+        inline void begin_catch_exception(const void *expected_faulty_addr, 
+        int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV){
+            begin_catch_exception_gcc(expected_faulty_addr,si_code,rv_code,si_signo);
+        }
+        inline void begin_catch_exception(const void **expected_faulty_addr, 
+        int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV){
+            begin_catch_exception_gcc(expected_faulty_addr,si_code,rv_code,si_signo);
+        }
+    #endif
 
 #endif

--- a/lib/posix/signal.cpp
+++ b/lib/posix/signal.cpp
@@ -1,8 +1,4 @@
 #include "include/signal.hpp"
-#include "include/builtin.hpp"
-#include <cstdlib>
-#include <cstdio>
-#include <vector>
 
 // information recorded for exception checking
 struct sigact_record_t {
@@ -65,12 +61,12 @@ void FORCE_INLINE begin_catch_exception_common() {
   }
 }
 
-void begin_catch_exception(const void *expected_faulty_addr, int si_code, int rv_code, int si_signo) {
+void begin_catch_exception_gcc(const void *expected_faulty_addr, int si_code, int rv_code, int si_signo) {
   if(svp < 0) begin_catch_exception_common();
   sigact_stack[++svp] = {expected_faulty_addr, si_signo, si_code, rv_code};
 }
 
-void begin_catch_exception(const void **expected_faulty_addr, int si_code, int rv_code, int si_signo) {
+void begin_catch_exception_gcc(const void **expected_faulty_addr, int si_code, int rv_code, int si_signo) {
   if(svp < 0) begin_catch_exception_common();
   sigact_stack[++svp] = {expected_faulty_addr, si_signo, si_code, rv_code};
 }

--- a/lib/posix/signal.hpp
+++ b/lib/posix/signal.hpp
@@ -1,0 +1,13 @@
+#ifndef GCC_BUILTIN_SIGNAL_INCLUDED
+#define GCC_BUILTIN_SIGNAL_INCLUDED
+
+const int RT_CODE_MISMATCH  = -1;      // ERROR: mismatched signal
+const int RT_CODE_MAPERR    = 15;      // address not accessible
+const int RT_CODE_ACCERR    = 16;      // no permission to access
+
+// catch exception for non-execution on writable pages
+extern void begin_catch_exception_gcc(const void *expected_faulty_addr, int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV);
+extern void begin_catch_exception_gcc(const void **expected_faulty_addr, int si_code = 0, int rv_code = RT_CODE_ACCERR, int si_signo = SIGSEGV);
+extern void   end_catch_exception();
+
+#endif

--- a/lib/visualcpp/signal.cpp
+++ b/lib/visualcpp/signal.cpp
@@ -1,0 +1,108 @@
+#include "include/signal.hpp"
+
+// information recorded for exception checking
+struct exception_record_t{
+  enum {PTR,PTRPTR} tok;
+  union {
+    // faulty memory location: SIGILL, SIGFPE, SIGSEGV, SIGBUS, and SIGTRAP
+    const PVOID si_ExceptionAddress;
+    const PVOID *si_IndExceptionAddress;
+  };
+  DWORD si_ExceptionCode;
+  ULONG* si_ExceptionInformation;
+  int rv_code;
+  exception_record_t() = default;
+  exception_record_t (const PVOID si_ExceptionAddress, DWORD si_ExceptionCode, ULONG* si_ExceptionInformation, int rv_code):
+  tok(PTR), si_ExceptionAddress(si_ExceptionAddress), si_ExceptionCode(si_ExceptionCode), si_ExceptionInformation(si_ExceptionInformation),
+  rv_code(rv_code){};
+  exception_record_t (const PVOID *si_IndExceptionAddress, DWORD si_ExceptionCode, ULONG* si_ExceptionInformation, int rv_code):
+  tok(PTRPTR), si_ExceptionAddress(si_ExceptionAddress), si_ExceptionCode(si_ExceptionCode), si_ExceptionInformation(si_ExceptionInformation),
+  rv_code(rv_code){};
+  exception_record_t operator=(const exception_record_t & e){
+    if(e.tok == PTR)
+      return exception_record_t(e.si_ExceptionAddress,e.si_ExceptionCode,e.si_ExceptionInformation,e.rv_code);
+    else
+      return exception_record_t(e.si_IndExceptionAddress,e.si_ExceptionCode,e.si_ExceptionInformation,e.rv_code);
+  }
+};
+
+static std::vector<exception_record_t> sigact_stack(16);
+PVOID installed_handler = NULL;
+static int svp = -1;
+
+LONG WINAPI TopLevelUnhandledExceptionFilter(PEXCEPTION_POINTERS pExceptioninfo){
+    perror("begin_catch_nx_exception() fails to catch EXCEPTIONS!");
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+bool checkExceptInformation(ULONG* record_exceptionInfo, ULONG_PTR* exceptionInfo){
+
+  for(int i = 0; i != EXCEPTION_MAXIMUM_PARAMETERS; i++){
+    if(record_exceptionInfo[i] != exceptionInfo[i])
+      return false;
+  }
+  return true;
+
+}
+
+LONG WINAPI ExceptionHandler(struct _EXCEPTION_POINTERS* pExceptionInfo){
+  // check the exception cause
+  for(int i=svp; i>=0; i--) {
+    if((sigact_stack[i].si_ExceptionCode == pExceptionInfo->ExceptionRecord->ExceptionCode) &&
+       (sigact_stack[i].si_ExceptionInformation == NULL ||
+       checkExceptInformation(sigact_stack[i].si_ExceptionInformation,(pExceptionInfo->ExceptionRecord->ExceptionInformation))) &&
+      (sigact_stack[i].si_ExceptionAddress == NULL ||
+      sigact_stack[i].si_ExceptionAddress == pExceptionInfo->ExceptionRecord->ExceptionAddress))
+      exit(sigact_stack[i].rv_code);
+  }
+
+  fprintf(stderr, "ExceptionHandler(): mismatched signal with ExceptionCode = %d, ExceptionAddress = 0x%p\n",
+   pExceptionInfo->ExceptionRecord->ExceptionCode, pExceptionInfo->ExceptionRecord->ExceptionAddress);
+
+  fprintf(stderr,"ExceptionInformation is:");
+  for(int i = 0; i != EXCEPTION_MAXIMUM_PARAMETERS; i++){
+    fprintf(stderr," %d",pExceptionInfo->ExceptionRecord->ExceptionInformation[i]);
+  }
+  //if(sinfo->si_addr != NULL) fprintf(stderr, "bad data = 0x%lx\n", *(unsigned int *)sinfo->si_addr);
+  //for(int i=svp; i>=0; i--) {
+  //  fprintf(stderr, "registered sigact: si_signo = %d, si_code = %d and fault-addr = 0x%p\n", sigact_stack[i].si_signo, sigact_stack[i].si_code, sigact_stack[i].daddr);
+  //}
+  exit(RT_CODE_MISMATCH);
+  return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void begin_catch_exception_msvc(const PVOID expected_faulty_addr, ULONG* si_code,
+                      int rv_code, DWORD si_signo){
+    if(svp < 0){
+        if(SetUnhandledExceptionFilter(TopLevelUnhandledExceptionFilter) != NULL){
+            perror("SetUnhandledExceptionFilter() already has set TopLevelUnhandledExceptionFilter!");
+        }
+        installed_handler = AddVectoredExceptionHandler(0,ExceptionHandler);
+    }
+    sigact_stack[++svp] = {expected_faulty_addr, si_signo, si_code, rv_code};
+}
+
+void begin_catch_exception_msvc(const PVOID* expected_faulty_addr, ULONG* si_code,
+                      int rv_code, DWORD si_signo){
+    if(svp < 0){
+        if(SetUnhandledExceptionFilter(TopLevelUnhandledExceptionFilter) != NULL){
+            perror("SetUnhandledExceptionFilter() already has set TopLevelUnhandledExceptionFilter!");
+        }
+        installed_handler = AddVectoredExceptionHandler(0,ExceptionHandler);
+    }
+    sigact_stack[++svp] = {expected_faulty_addr, si_signo, si_code, rv_code};
+}
+
+void end_catch_exception() {
+  --svp;
+  if(svp < 0) {
+    if(SetUnhandledExceptionFilter(NULL) == NULL){
+      perror("SetUnhandledExceptionFilter() fails to set TopLevelUnhandledExceptionFilter previously!");
+      exit(-1);
+    }
+    if(!RemoveVectoredExceptionHandler(installed_handler)){
+      perror("end_catch_nx_exception() fails to reset Vectored Exception!");
+      exit(-1);
+    }
+  }
+}

--- a/lib/visualcpp/signal.hpp
+++ b/lib/visualcpp/signal.hpp
@@ -1,0 +1,17 @@
+#ifndef VISUALCPP_BUILTIN_SEH_INCLUDED
+#define VISUALCPP_BUILTIN_SEH_INCLUDED
+
+#include<Windows.h>
+#include<winnt.h>
+#include<Excpt.h>
+
+const int RT_CODE_MISMATCH  = -1;      // ERROR: mismatched signal
+const int RT_CODE_MAPERR    = 15;      // address not accessible
+const int RT_CODE_ACCERR    = 16;      // no permission to access
+
+// catch exception for non-execution on writable pages
+extern void begin_catch_exception_msvc(const PVOID expected_faulty_addr, ULONG* si_code = NULL, int rv_code = RT_CODE_ACCERR, DWORD si_signo = EXCEPTION_ACCESS_VIOLATION);
+extern void begin_catch_exception_msvc(const PVOID* expected_faulty_addr, ULONG* si_code = NULL, int rv_code = RT_CODE_ACCERR, DWORD si_signo = EXCEPTION_ACCESS_VIOLATION);
+extern void   end_catch_exception();
+
+#endif


### PR DESCRIPTION
        *apart builtin and signal header files to different dirs
        according to different OS C/C++ Library
        *use VEH(Vector Exception Handing) to register exception
         handler and add exception nums which is mapping
         to linux signal(may not accurate,stil need further test)
        *replace begin_catch_exception() with
        begin_catch_exception_wrapper() to smooth the gap between diff
        CAPI
        *add copy-assgin operator function in struct exception_record_t
        otherwise it will raise MSVC error C2280
        (function "exception_record t::operator=(const exception_record t &)" (declared implicitly) cannot be referenced -- it is a deleted function)
        because MSVC would surpress default copy-assign operator func
	*add comment for ABI/API indepdent header files
	*standardized naming for begin/end_catch_exception