### PR TITLE
Fix: Lack of argument

### DIFF
--- a/configure.json
+++ b/configure.json
@@ -2575,7 +2575,12 @@
         },
         "require": {
             "0": []
-        }
+        },
+        "offset": [
+            0,
+            2,
+            1
+        ]
     },
     "mss-write-by-bare-array-index-overflow-stack": {
         "program": "mss-write-by-bare-array-index",


### PR DESCRIPTION
Adapted from PR #140.

Testcase mss-write-by-stack-pointer can't work because of the lack of the argument "offset".