### PR TITLE
Fix: Compile error when enable_stack_protection = yes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ else
   ifdef enable_stack_protection
     CXXFLAGS += -Wstack-protector -fstack-protector-all
   ifeq ($(ARCH),x86_64)
-    CXXFLAGS += -mstack-protector-guard=guard
+    CXXFLAGS += -mstack-protector-guard=global
   endif
   endif
 


### PR DESCRIPTION
Adapted from PR #141.

The value of compile option "-mstack-protector-guard" should be "global" instead of "guard", because "guard" is not an optional value for this option. All the testcases failed to be built without this fix.