### PR TITLE
New test: cfi-return-to-parent-non-call-site-by-asmfunc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ else
     func-opcode-gen := ./script/get_riscv64_func_inst.sh
   endif
   dynlibcfi := $(addsuffix $(DLL_SUFFIX), lib/common/libcfi)
-  independent_assembly := 
+  independent_assembly := $(addprefix lib/$(ARCH)/, indepassembly.o)
 
   ifeq ($(CXX),$(filter $(CXX),clang++ c++))
     ifneq ($(OSType),Darwin)

--- a/cfi/return-to-parent-non-call-site-by-asmfunc.cpp
+++ b/cfi/return-to-parent-non-call-site-by-asmfunc.cpp
@@ -1,0 +1,31 @@
+#include <cstdlib>
+#include "include/global_var.hpp"
+#include <string>
+
+volatile arch_int_t offset;
+int main(int argc, char* argv[]){
+
+  INIT_TRACE_FILE;
+  gvar_init(1);
+  // get the offset of RA on stack
+  if(argc == 2){
+    std::string cmd_offset = argv[1];
+    offset = 4 * stoll(cmd_offset);
+  }else{
+    std::string cmd_offset = argv[1];
+    std::string extra_offset = argv[2];
+    offset = 4*(stoll(cmd_offset) + stoll(extra_offset));
+  }
+  void *ret_label = (void*)&main;
+  GET_LABEL_ADDRESS(ret_label,TARGET_LABEL);
+  if(offset == -1) { GOTO_SAVED_LABEL(ret_label);}   // impossible to happen
+
+  // call a function but illegally return
+  assembly_helper(ret_label);
+  gvar_decr();
+  COMPILER_BARRIER;
+  // the elligal return site
+TARGET_LABEL(argc)
+  gvar_decr();
+  exit(gvar());
+}

--- a/configure.json
+++ b/configure.json
@@ -7090,6 +7090,32 @@
             "290": "cheri capabilities enabled."
         }
     },
+    "cfi-return-to-parent-non-call-site-by-asmfunc": {
+        "get-code-offset": {
+            "0": [
+                "main",
+                "labelfunc"
+            ]
+        },
+        "arguments": {
+            "0": [
+                "-rsize"
+            ]
+        },
+        "default_args": {
+            "0": [
+                "-rsize"
+            ]
+        },
+        "size": [
+            0,
+            16,
+            1
+        ],
+        "expect-results": {
+            "290": "cheri capabilities enabled."
+        }
+    },
     "cfi-return-to-parent-same-call-site": {
         "comment": "add chain type support",
         "require-comment": [

--- a/lib/aarch64/assembly.hpp
+++ b/lib/aarch64/assembly.hpp
@@ -1,6 +1,8 @@
 // assembly helper functions
 // riscv64
 
+extern "C" void assembly_helper(void* target_address);
+
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/aarch64/indepassembly.asm
+++ b/lib/aarch64/indepassembly.asm
@@ -1,0 +1,12 @@
+.section .text
+.globl assembly_helper
+.globl exit
+.type exit, %function
+
+assembly_helper:
+  sub sp, sp, #0x10
+  stp x29, x30, [sp]
+  str x0,[sp,#0x8]
+  ldp x29,x30,[sp]
+  add sp,sp,#0x10
+  ret

--- a/lib/cheri_riscv64/assembly.hpp
+++ b/lib/cheri_riscv64/assembly.hpp
@@ -1,3 +1,5 @@
+extern "C" void assembly_helper(void* target_address);
+
   // get the distance between two pointers
   #define GET_DISTANCE(dis, pa, pb)            \
     asm volatile(                              \

--- a/lib/cheri_riscv64/indepassembly.asm
+++ b/lib/cheri_riscv64/indepassembly.asm
@@ -1,0 +1,19 @@
+.section .text
+.globl assembly_helper
+.globl exit
+.type exit, @function
+
+assembly_helper:
+  addi sp, sp, -16
+  # save return address
+  sd ra, 8(sp)
+  # save frame pointer
+  sd s0, 0(sp)
+  # modify return address
+  sd a0, 8(sp)
+  # restore frame pointer
+  ld s0, 0(sp)
+  # restore return address
+  ld ra, 8(sp)
+  addi sp, sp, 16
+  ret

--- a/lib/riscv64/assembly.hpp
+++ b/lib/riscv64/assembly.hpp
@@ -1,6 +1,7 @@
 // assembly helper functions
 // riscv64
 
+extern "C" void assembly_helper(void* target_address);
 
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \

--- a/lib/riscv64/indepassembly.asm
+++ b/lib/riscv64/indepassembly.asm
@@ -1,0 +1,19 @@
+.section .text
+.globl assembly_helper
+.globl exit
+.type exit, @function
+
+assembly_helper:
+  addi sp, sp, -16
+  # save return address
+  sd ra, 8(sp)
+  # save frame pointer
+  sd s0, 0(sp)
+  # modify return address
+  sd a0, 8(sp)
+  # restore frame pointer
+  ld s0, 0(sp)
+  # restore return address
+  ld ra, 8(sp)
+  addi sp, sp, 16
+  ret

--- a/lib/x86_64/assembly.hpp
+++ b/lib/x86_64/assembly.hpp
@@ -1,6 +1,8 @@
 // assembly helper functions
 // x86_64 gcc
 
+extern "C" void assembly_helper(void* target_address);
+
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \
   asm volatile(                              \

--- a/lib/x86_64/indepassembly.asm
+++ b/lib/x86_64/indepassembly.asm
@@ -1,0 +1,13 @@
+.section .text
+.globl assembly_helper
+.globl exit
+.type exit, %function
+
+assembly_helper:
+  # Save address
+  movq %rdi, %rax
+  # Pop the return address from the stack
+  popq %rbx
+  # Save the fake return address to the stack
+  pushq %rax
+  ret


### PR DESCRIPTION
Adapted from #145.

This new test uses an assembly function in the new files in lib/ to attack. 