### PR TITLE
New test: cfi-return-to-peer-asmfunc

### DIFF
--- a/cfi/return-to-peer-asmfunc.cpp
+++ b/cfi/return-to-peer-asmfunc.cpp
@@ -1,0 +1,39 @@
+#include <cstdlib>
+#include "include/global_var.hpp"
+#include <string>
+
+volatile arch_int_t offset = 0;
+
+void FORCE_NOINLINE helper(void * label) {
+
+  GET_RAA_SP_OFFSET(offset);
+  #ifdef TRACE_RUN
+    GET_SP_BASE(ra_addr);
+    WRITE_TRACE("RA address: 0x", ra_addr);
+    WRITE_TRACE("RA before modified: 0x", *(long long*)ra_addr);
+  #endif
+  MOD_STACK_DAT(label, offset);
+  WRITE_TRACE("RA address: 0x", ra_addr);
+  WRITE_TRACE("RA after modified: 0x", *(long long*)ra_addr);
+  /* HiFive Unmatched, GCC 11.2.0
+   * Make sure offset is modified as otherwise
+   * the stack is not expanded similarily with
+   * the return-to-parent-same-call-site test.
+   */
+  offset = rand();
+}
+
+int main(int argc, char* argv[])
+{
+  INIT_TRACE_FILE;
+  // get the offset of RA on stack
+  std::string cmd_offset = argv[1];
+  // fake compiler
+  char gvar_val = argv[2][0];
+  offset = 4 * stoll(cmd_offset);
+  gvar_init(strtol(&gvar_val, NULL, 0));
+  void *label = (void *)(assembly_return_site);
+  helper(label);
+  gvar_decr();
+  return gvar();
+}

--- a/configure.json
+++ b/configure.json
@@ -7227,6 +7227,28 @@
             "290": "cheri capabilities enabled."
         }
     },
+    "cfi-return-to-peer-asmfunc": {
+        "arguments": {
+            "0": [
+                "-vstack-offset-v-p-g1",
+                "2"
+            ]
+        },
+        "default_args": {
+            "0": [
+                "-rsize",
+                "2"
+            ]
+        },
+        "size": [
+            0,
+            16,
+            1
+        ],
+        "expect-results": {
+            "290": "cheri capabilities enabled."
+        }
+    },
     "cfi-return-to-peer-func": {
         "require-comment": [
             "relaxation"
@@ -7234,7 +7256,7 @@
         "require": {
             "0": [
                 [
-                    "cfi-return-to-parent-wrong-call-site"
+                    "cfi-return-to-peer-asmfunc"
                 ]
             ]
         },

--- a/lib/aarch64/assembly.hpp
+++ b/lib/aarch64/assembly.hpp
@@ -2,6 +2,7 @@
 // riscv64
 
 extern "C" void assembly_helper(void* target_address);
+extern "C" void assembly_return_site();
 
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \

--- a/lib/aarch64/indepassembly.asm
+++ b/lib/aarch64/indepassembly.asm
@@ -1,5 +1,6 @@
 .section .text
 .globl assembly_helper
+.globl assembly_return_site
 .globl exit
 .type exit, %function
 
@@ -9,4 +10,16 @@ assembly_helper:
   str x0,[sp,#0x8]
   ldp x29,x30,[sp]
   add sp,sp,#0x10
+  ret
+
+assembly_return_site:
+  # Save the stack info
+  push %rbp
+  movq %rsp, %rbp
+  # Set exit code
+  xor %rdi, %rdi
+  call exit
+  # Restore stack info
+  movq %rbp, %rsp
+  pop %rbp
   ret

--- a/lib/cheri_riscv64/assembly.hpp
+++ b/lib/cheri_riscv64/assembly.hpp
@@ -1,4 +1,5 @@
 extern "C" void assembly_helper(void* target_address);
+extern "C" void assembly_return_site();
 
   // get the distance between two pointers
   #define GET_DISTANCE(dis, pa, pb)            \

--- a/lib/cheri_riscv64/indepassembly.asm
+++ b/lib/cheri_riscv64/indepassembly.asm
@@ -1,5 +1,6 @@
 .section .text
 .globl assembly_helper
+.globl assembly_return_site
 .globl exit
 .type exit, @function
 
@@ -16,4 +17,16 @@ assembly_helper:
   # restore return address
   ld ra, 8(sp)
   addi sp, sp, 16
+  ret
+
+assembly_return_site:
+  # Save the stack info
+  push %rbp
+  movq %rsp, %rbp
+  # Set exit code
+  xor %rdi, %rdi
+  call exit
+  # Restore stack info
+  movq %rbp, %rsp
+  pop %rbp
   ret

--- a/lib/riscv64/assembly.hpp
+++ b/lib/riscv64/assembly.hpp
@@ -2,6 +2,7 @@
 // riscv64
 
 extern "C" void assembly_helper(void* target_address);
+extern "C" void assembly_return_site();
 
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \

--- a/lib/riscv64/indepassembly.asm
+++ b/lib/riscv64/indepassembly.asm
@@ -1,5 +1,6 @@
 .section .text
 .globl assembly_helper
+.globl assembly_return_site
 .globl exit
 .type exit, @function
 
@@ -16,4 +17,16 @@ assembly_helper:
   # restore return address
   ld ra, 8(sp)
   addi sp, sp, 16
+  ret
+
+  assembly_return_site:
+  # Save the stack info
+  push %rbp
+  movq %rsp, %rbp
+  # Set exit code
+  xor %rdi, %rdi
+  call exit
+  # Restore stack info
+  movq %rbp, %rsp
+  pop %rbp
   ret

--- a/lib/x86_64/assembly.hpp
+++ b/lib/x86_64/assembly.hpp
@@ -2,6 +2,7 @@
 // x86_64 gcc
 
 extern "C" void assembly_helper(void* target_address);
+extern "C" void assembly_return_site();
 
 // get the distance between two pointers
 #define GET_DISTANCE(dis, pa, pb)            \

--- a/lib/x86_64/indepassembly.asm
+++ b/lib/x86_64/indepassembly.asm
@@ -1,5 +1,6 @@
 .section .text
 .globl assembly_helper
+.globl assembly_return_site
 .globl exit
 .type exit, %function
 
@@ -10,4 +11,16 @@ assembly_helper:
   popq %rbx
   # Save the fake return address to the stack
   pushq %rax
+  ret
+
+assembly_return_site:
+  # Save the stack info
+  push %rbp
+  movq %rsp, %rbp
+  # Set exit code
+  xor %rdi, %rdi
+  call exit
+  # Restore stack info
+  movq %rbp, %rsp
+  pop %rbp
   ret


### PR DESCRIPTION
Adapted from #145.

This new test uses another assembly function added in the new files in lib/ to attack.