### PR TITLE
Fix: Can't run new tests in Windows

### DIFF
--- a/cfi/return-to-parent-same-call-site-diffargs.cpp
+++ b/cfi/return-to-parent-same-call-site-diffargs.cpp
@@ -5,7 +5,7 @@
 volatile arch_int_t offset;
 volatile arch_int_t fake_val;
 
-void* FORCE_NOINLINE helper(void *label, int get_offset_method, int get_ra_method) {
+FORCE_NOINLINE void* helper(void *label, int get_offset_method, int get_ra_method) {
   void* curr_return_addr = NULL;
   if(get_ra_method){
     READ_STACK_DAT(curr_return_addr, offset);
@@ -46,9 +46,9 @@ void* FORCE_NOINLINE helper(void *label, int get_offset_method, int get_ra_metho
   }
 }
 
-void* FORCE_NOINLINE helper(void *label, int sel) {
-  void* curr_return_addr = NULL;
-  GET_RA_ADDR(curr_return_addr);
+FORCE_NOINLINE void* helper(void *label, int sel) {
+  void *curr_return_addr = NULL;
+  READ_STACK_DAT(curr_return_addr, offset);
   gvar_incr();
   volatile void * buf[2];
   if(gvar() == 2) {

--- a/cfi/return-to-parent-same-call-site.cpp
+++ b/cfi/return-to-parent-same-call-site.cpp
@@ -20,8 +20,11 @@ void FORCE_NOINLINE helper(void *label, int sel) {
       WRITE_TRACE("RA address: 0x", ra_addr);
       WRITE_TRACE("RA before modified: 0x", *(long long*)ra_addr);
     #endif
-    if(sel) MOD_STACK_DAT(label, offset);
-    else *(buf+offset) = label;
+    if(sel) {
+      MOD_STACK_DAT(label, offset);
+    } else {
+      *(buf+offset) = label;
+    }
     WRITE_TRACE("RA address: 0x", ra_addr);
     WRITE_TRACE("RA after modified: 0x", *(long long*)ra_addr);
   }

--- a/cfi/return-to-parent-wrong-call-site-fakefunc.cpp
+++ b/cfi/return-to-parent-wrong-call-site-fakefunc.cpp
@@ -25,7 +25,7 @@ void FORCE_NOINLINE helper(void *label) {
   offset = rand();
 }
 
-void* FORCE_NOINLINE helper2(int val) {
+FORCE_NOINLINE void* helper2(int val) {
   void* curr_return_addr = NULL;
   READ_STACK_DAT(curr_return_addr, offset);
   if(fake_init_val > 0) gvar_init(fake_init_val); //impossible to happen

--- a/lib/common/cfi.cpp
+++ b/lib/common/cfi.cpp
@@ -33,7 +33,10 @@ void Base_1v::virtual_func(void*) {
   exit(1);
 }
 
-volatile arch_int_t cfi_offset;
+#if defined(COMPILER_MSVC)
+  CONTEXT sp_loc_context;
+  // Used in Windows for GET_RAA_OFFSET and MOD_STACK_DAT
+#endif 
 
 void Ret_From_Helper::virtual_func(void *label) {
   COMPILER_BARRIER;

--- a/lib/include/cfi.hpp
+++ b/lib/include/cfi.hpp
@@ -21,6 +21,7 @@ typedef pfunc_t *pvtable_t;
 DLL_DEFINITION extern pvtable_t create_fake_vtable_on_heap(unsigned int nfunc);
 DLL_DEFINITION extern void free_fake_vtable_on_heap(pvtable_t addr);
 
+volatile arch_int_t cfi_offset;
 
 class DLL_DEFINITION Base
 {

--- a/lib/x86_64/visualcpp_assembly.hpp
+++ b/lib/x86_64/visualcpp_assembly.hpp
@@ -8,6 +8,8 @@
 #define X64_MSVC_ASSEMBLY_HPP_INCLUDED
 
 extern "C" void push_fake_ret(void*,  arch_int_t);
+extern "C" void assembly_helper(void* target_address);
+extern "C" void assembly_return_site();
 
 union x{void(*func_ptr)(); long long func_num;};
 GLOBAR_VAR_PRE x jum_target;

--- a/lib/x86_64/visualcpp_indepassembly_func.asm
+++ b/lib/x86_64/visualcpp_indepassembly_func.asm
@@ -1,3 +1,5 @@
+EXTERN exit:PROC
+
 .code _text
 
 option casemap:none
@@ -20,7 +22,7 @@ push_fake_ret ENDP
 
 assembly_helper PROC PUBLIC
                 ; Save address
-                mov     rax,rdi;
+                mov     rax,rcx;
                 ; Pop the return address from the stack
                 pop     rbx;
                 ; Save the fake return address to the stack
@@ -33,8 +35,8 @@ assembly_return_site PROC PUBLIC
                 push    rbp;
                 mov     rbp,rsp;
                 ; Set exit code
-                xor     rdi,rdi;
-                call exit
+                mov     rcx,0;
+                call    exit;
                 ; Restore stack info
                 mov     rsp,rbp;
                 pop     rbp;

--- a/lib/x86_64/visualcpp_indepassembly_func.asm
+++ b/lib/x86_64/visualcpp_indepassembly_func.asm
@@ -18,4 +18,27 @@ exitcode:       push rax;
 
 push_fake_ret ENDP
 
+assembly_helper PROC PUBLIC
+                ; Save address
+                mov     rax,rdi;
+                ; Pop the return address from the stack
+                pop     rbx;
+                ; Save the fake return address to the stack
+                push    rax;
+                ret;
+assembly_helper ENDP
+
+assembly_return_site PROC PUBLIC
+                ; Save the stack info
+                push    rbp;
+                mov     rbp,rsp;
+                ; Set exit code
+                xor     rdi,rdi;
+                call exit
+                ; Restore stack info
+                mov     rsp,rbp;
+                pop     rbp;
+                ret;
+assembly_return_site ENDP
+
 END


### PR DESCRIPTION
Fix the bugs caused by those new cfi tests added in last 5 PR. Now they can run normally in both Windows and Linux.