### PR TITLE
New scripts: Batch run tests in x64 Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ run-test
 .vs/
 *.xml
 *.csv
+!batch-option/*.csv

--- a/batch-option/batch-option-i712_x64_linux.csv
+++ b/batch-option/batch-option-i712_x64_linux.csv
@@ -1,0 +1,14 @@
+X86-64-Lin-G,exhausted-run,CXX=g++
+X86-64-Lin-L,exhausted-run,CXX=clang++
+GCC-ASan-address,exhausted-run,CXX=g++,enable_default_address_sanitizer="yes"
+LLVM-ASan-address,exhausted-run,CXX=clang++,enable_default_address_sanitizer="yes"
+GCC-ASan-undefined,exhausted-run,CXX=g++,enable_undefined_sanitizer="yes"
+LLVM-ASan-undefined,exhausted-run,CXX=clang++,enable_undefined_sanitizer="yes"
+LLVM-Safe-stack,exhausted-run,CXX=clang++,enable_safe_stack="yes"
+GCC-ASan-full,exhausted-run,CXX=g++,enable_full_address_sanitizer="yes",enable_full_undefined_sanitizer="yes"
+LLVM-ASan-full,exhausted-run,CXX=clang++,enable_full_address_sanitizer="yes",enable_full_undefined_sanitizer="yes"
+G12-GCC-stack,exhausted-run,CXX=g++,enable_stack_protection="yes",enable_stack_clash_protection="yes"
+G12-GCC-CET,exhausted-run,CXX=g++,enable_cet_shadow_stack="yes",GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK
+G12-GCC-FULL,exhausted-run,CC=gcc,CXX=g++,enable_stack_protection="yes",enable_stack_clash_protection="yes",enable_cet_shadow_stack="yes",GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK,enable_vtable_verify="yes",enable_fortify_source="yes"
+G12-LLVM-full,exhausted-run,CXX=clang++,enable_stack_protection="yes",enable_stack_clash_protection="yes",enable_cet_shadow_stack="yes",GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK,enable_fortify_source="yes"
+G12-GCC-vtv,exhausted-run,CC=gcc,CXX=g++,enable_vtable_verify="yes"

--- a/script/run_test_in_batch.sh
+++ b/script/run_test_in_batch.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set +x
+#ensure the input csv has one blank line in the last, read command need linke break, else would read the last line
+# Check if the correct number of arguments is provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <csv_file> [0:parrlel 1:sequential]"
+    exit 1
+fi
+
+# Read the CSV file specified as a command-line argument
+csv_file="$1"
+run_method="$2"
+. ./script/subscript-function.sh
+
+collect_dir="results"
+(
+cd ..
+rm -rf "$collect_dir"
+mkdir -p "$collect_dir"
+)
+
+one_run_ind=0
+# Read the CSV file
+while IFS=, read -r prefix mode rest_columns; do
+    # copy test bench directory and enter work directory
+
+    if [ "$one_run_ind" -ne 0 ]; then
+        new_dir="cpu-sec-bench-$one_run_ind"
+        cd ..
+        rm -rf "$new_dir"
+        cp -r cpu-sec-bench "$new_dir"
+        cd cpu-sec-bench-$one_run_ind || (
+            echo "$new_dir"
+            exit 1
+        )
+    fi
+
+    if [ "$run_method" -eq 0 ]; then
+        (
+            export_func "$rest_columns"
+            run_test "$prefix" "$mode" "$collect_dir"
+        )&
+    else
+        (
+            export_func "$rest_columns"
+            run_test "$prefix" "$mode" "$collect_dir"
+        )
+    fi
+
+    one_run_ind=$((one_run_ind + 1))
+done < "$csv_file"
+
+wait

--- a/script/subscript-function.sh
+++ b/script/subscript-function.sh
@@ -1,0 +1,50 @@
+
+#! /bin/sh
+
+# keep log name same with result name
+rename_log() {
+	if log_name=$(ls -t *.dat); then
+		log_name=$(echo "${log_name}" | head -n 1)
+		base_name="${log_name%.*}"
+		# return base_name
+		echo "$base_name"
+	else
+		exit 1
+	fi
+}
+
+run_test(){
+	make cleanall >temp.log 2>&1
+	make -e >>temp.log 2>&1
+	./run-test "$2" >>temp.log 2>&1
+	base_name=$(rename_log)
+	final_name="$1"_"${base_name}"
+	echo "$final_name"
+	mv temp.log "$final_name".log
+	mv "${base_name}".dat "$final_name".dat
+
+	collect_results ../"$3"
+}
+
+collect_results() {
+
+	# Find and copy .dat files
+	find . -name "*.dat" -exec cp {} "$1" \;
+
+	# Find and copy .log files
+	find . -name "*.log" -exec cp {} "$1" \;
+}
+
+export_func(){
+	rest_columns="$1"
+	# Split rest_columns with comma into an array
+	IFS=,
+	set -- "$rest_columns"
+	columns_array="$@"
+
+	# Iterate over the columns array
+	for column in $columns_array; do
+		export "$column"
+	done
+
+}


### PR DESCRIPTION
Adapted from #143.

script/subscript-function.sh: provide some useful functions

script/run_test_in_batch.sh: batch run tests. For each test, it will build a new copy of the cpu-sec-bench (I doubt whether this is appropriate) and compile with different options. After all the tests finished, it will collect the results in a new directory named "results".

batch-option/: the .csv files in this directory are used to run tests in different OS and architecture. They record the name of the tests, the mode, and the compile options. When running script/run_test_in_batch.sh, you need to indicate which .csv file you want to use. More batch-options in PR#143 will be supplemented if this PR is merged.